### PR TITLE
Llama: Keep weights stationary in dedicated buffers

### DIFF
--- a/applications/llama_3.2_1b/inference.py
+++ b/applications/llama_3.2_1b/inference.py
@@ -138,6 +138,16 @@ def inference(
     )
     logging.info("Model and tokenizer loaded.")
 
+    # Important: Set the seed again after initialization of the model. Each
+    # call that initializes an nn.Linear layer updates the RNG state, because
+    # weights are initialized with random values. For different JSON
+    # configurations, we initialize a different number of linear layers,
+    # so different configurations result in a different RNG state here. Since
+    # we use random numbers to sample from the token distribution during
+    # inference, it is important to have the same RNG state between runs so we
+    # can have reproducible results across configurations.
+    torch.manual_seed(1608560892)
+
     hook_handles = []
     if save_outputs:
         if os.path.exists(output_data_path):

--- a/applications/llama_3.2_1b/inference.py
+++ b/applications/llama_3.2_1b/inference.py
@@ -138,12 +138,6 @@ def inference(
     )
     logging.info("Model and tokenizer loaded.")
 
-    logging.info("Preparing AIE operators...")
-    # At this point the model is fully described (operators and their dimensions and how to compile them)
-    AIEOperatorBase.compile_all_operators()
-    AIEOperatorBase.prepare_runtime()
-    logging.info("AIE operator preparation completed.")
-
     hook_handles = []
     if save_outputs:
         if os.path.exists(output_data_path):
@@ -195,6 +189,11 @@ def inference(
     model.to(device)
     del combined_weights
 
+    logging.info("Preparing AIE operators...")
+    # At this point the model is fully described (operators and their dimensions and how to compile them)
+    AIEOperatorBase.compile_all_operators()
+    AIEOperatorBase.prepare_runtime()
+    logging.info("AIE operator preparation completed.")
     print(f"Starting text generation...")
     print(f"Generating {num_tokens} tokens...")
     print("=" * 55)

--- a/applications/llama_3.2_1b/src/block/feed_forward.py
+++ b/applications/llama_3.2_1b/src/block/feed_forward.py
@@ -63,6 +63,16 @@ class FeedForward(nn.Module):
             self.fc3 = AIEGEMM(
                 M=M_prefill, K=self.hidden_dim, N=self.emb_dim, **aie_config_prefill
             )
+        else:
+            self.fc1 = nn.Linear(
+                cfg["emb_dim"], cfg["hidden_dim"], dtype=cfg["dtype"], bias=False
+            )
+            self.fc2 = nn.Linear(
+                cfg["emb_dim"], cfg["hidden_dim"], dtype=cfg["dtype"], bias=False
+            )
+            self.fc3 = nn.Linear(
+                cfg["hidden_dim"], cfg["emb_dim"], dtype=cfg["dtype"], bias=False
+            )
 
         if self.cfg["use_kv_cache"] and self.cfg["use_aie_gemv"]:
             aie_gemv_config = {"num_columns": 1, "is_mv": False}

--- a/applications/llama_3.2_1b/src/block/feed_forward.py
+++ b/applications/llama_3.2_1b/src/block/feed_forward.py
@@ -25,10 +25,6 @@ class FeedForward(nn.Module):
         super().__init__()
         self.cfg = cfg.copy()
 
-        assert cfg["use_aie_ffn_swiglu"] != (
-            cfg["use_aie_ffn_silu"] or cfg["use_aie_ffn_gemm"] or cfg["use_aie_ffn_mul"]
-        ), "Cannot mix fused SwiGLU with individual AIE operators."
-
         self.emb_dim = cfg["emb_dim"]
         self.hidden_dim = cfg["hidden_dim"]
 
@@ -106,8 +102,8 @@ class FeedForward(nn.Module):
         is_prefill = not is_vector or not self.cfg["use_kv_cache"]
 
         if is_vector and self.cfg["use_kv_cache"] and self.cfg["use_aie_gemv"]:
-            x_fc1 = self.aie_fc1_gemv(None, x)
-            x_fc2 = self.aie_fc2_gemv(None, x)
+            x_fc1 = self.aie_fc1_gemv(x)
+            x_fc2 = self.aie_fc2_gemv(x)
         else:
             x_fc1 = self.fc1(x)
             x_fc2 = self.fc2(x)
@@ -120,7 +116,7 @@ class FeedForward(nn.Module):
             x = x_fc1_silu * x_fc2
 
         if is_vector and self.cfg["use_kv_cache"] and self.cfg["use_aie_gemv"]:
-            result = self.aie_fc3_gemv(None, x)
+            result = self.aie_fc3_gemv(x)
             return result.view(original_shape)
         else:
             return self.fc3(x).view(original_shape)

--- a/applications/llama_3.2_1b/src/block/feed_forward.py
+++ b/applications/llama_3.2_1b/src/block/feed_forward.py
@@ -109,9 +109,8 @@ class FeedForward(nn.Module):
         )
 
         is_decode_with_kv = is_vector and self.cfg["use_kv_cache"]
-        is_prefill = not is_vector or not self.cfg["use_kv_cache"]
 
-        if is_vector and self.cfg["use_kv_cache"] and self.cfg["use_aie_gemv"]:
+        if is_decode_with_kv and self.cfg["use_aie_gemv"]:
             x_fc1 = self.aie_fc1_gemv(x)
             x_fc2 = self.aie_fc2_gemv(x)
         else:
@@ -125,7 +124,7 @@ class FeedForward(nn.Module):
         else:
             x = x_fc1_silu * x_fc2
 
-        if is_vector and self.cfg["use_kv_cache"] and self.cfg["use_aie_gemv"]:
+        if is_decode_with_kv and self.cfg["use_aie_gemv"]:
             result = self.aie_fc3_gemv(x)
             return result.view(original_shape)
         else:

--- a/applications/llama_3.2_1b/src/block/feed_forward.py
+++ b/applications/llama_3.2_1b/src/block/feed_forward.py
@@ -8,7 +8,7 @@
 
 import torch
 import torch.nn as nn
-from ..utils import torch_to_numpy
+from ..utils import torch_to_numpy, assign
 from src.operator.aie_elementwise_mul import AIEElementwiseMul
 from src.operator.aie_gemm import AIEGEMM
 from src.operator.aie_gemv import AIEGEMV
@@ -25,16 +25,9 @@ class FeedForward(nn.Module):
         super().__init__()
         self.cfg = cfg.copy()
 
-        # Weights for FFN
-        self.fc1 = nn.Linear(
-            cfg["emb_dim"], cfg["hidden_dim"], dtype=cfg["dtype"], bias=False
-        )
-        self.fc2 = nn.Linear(
-            cfg["emb_dim"], cfg["hidden_dim"], dtype=cfg["dtype"], bias=False
-        )
-        self.fc3 = nn.Linear(
-            cfg["hidden_dim"], cfg["emb_dim"], dtype=cfg["dtype"], bias=False
-        )
+        assert cfg["use_aie_ffn_swiglu"] != (
+            cfg["use_aie_ffn_silu"] or cfg["use_aie_ffn_gemm"] or cfg["use_aie_ffn_mul"]
+        ), "Cannot mix fused SwiGLU with individual AIE operators."
 
         self.emb_dim = cfg["emb_dim"]
         self.hidden_dim = cfg["hidden_dim"]
@@ -62,15 +55,16 @@ class FeedForward(nn.Module):
                 "tile_m": 64,
                 "tile_k": 64,
                 "tile_n": 64,
+                "use_static_weight": True,
             }
 
-            self.aie_fc1_prefill = AIEGEMM(
+            self.fc1 = AIEGEMM(
                 M=M_prefill, K=self.emb_dim, N=self.hidden_dim, **aie_config_prefill
             )
-            self.aie_fc2_prefill = AIEGEMM(
+            self.fc2 = AIEGEMM(
                 M=M_prefill, K=self.emb_dim, N=self.hidden_dim, **aie_config_prefill
             )
-            self.aie_fc3_prefill = AIEGEMM(
+            self.fc3 = AIEGEMM(
                 M=M_prefill, K=self.hidden_dim, N=self.emb_dim, **aie_config_prefill
             )
 
@@ -112,15 +106,8 @@ class FeedForward(nn.Module):
         is_prefill = not is_vector or not self.cfg["use_kv_cache"]
 
         if is_vector and self.cfg["use_kv_cache"] and self.cfg["use_aie_gemv"]:
-            x_fc1 = self.aie_fc1_gemv(self.fc1.weight.T, x)
-            x_fc2 = self.aie_fc2_gemv(self.fc2.weight.T, x)
-        elif self.cfg["use_aie_ffn_gemm"]:
-            if is_decode_with_kv:
-                x_fc1 = self.fc1(x)
-                x_fc2 = self.fc2(x)
-            else:
-                x_fc1 = self.aie_fc1_prefill(x, self.fc1.weight.T)
-                x_fc2 = self.aie_fc2_prefill(x, self.fc2.weight.T)
+            x_fc1 = self.aie_fc1_gemv(None, x)
+            x_fc2 = self.aie_fc2_gemv(None, x)
         else:
             x_fc1 = self.fc1(x)
             x_fc2 = self.fc2(x)
@@ -133,12 +120,29 @@ class FeedForward(nn.Module):
             x = x_fc1_silu * x_fc2
 
         if is_vector and self.cfg["use_kv_cache"] and self.cfg["use_aie_gemv"]:
-            result = self.aie_fc3_gemv(self.fc3.weight.T, x)
+            result = self.aie_fc3_gemv(None, x)
             return result.view(original_shape)
-        elif self.cfg["use_aie_ffn_gemm"]:
-            if is_decode_with_kv:
-                return self.fc3(x).view(original_shape)
-            else:
-                return self.aie_fc3_prefill(x, self.fc3.weight.T)
         else:
             return self.fc3(x).view(original_shape)
+
+    def assign_weights(self, l, fc1, fc2, fc3):
+        self.fc1.weight = assign(
+            self.fc1.weight,
+            fc1,
+            f"model.layers.{l}.mlp.gate_proj.weight",
+        )
+        self.fc2.weight = assign(
+            self.fc2.weight,
+            fc2,
+            f"model.layers.{l}.mlp.up_proj.weight",
+        )
+        self.fc3.weight = assign(
+            self.fc3.weight,
+            fc3,
+            f"model.layers.{l}.mlp.down_proj.weight",
+        )
+
+        if self.cfg["use_kv_cache"] and self.cfg["use_aie_gemv"]:
+            self.aie_fc1_gemv.weight = fc1
+            self.aie_fc2_gemv.weight = fc2
+            self.aie_fc3_gemv.weight = fc3

--- a/applications/llama_3.2_1b/src/block/gqa.py
+++ b/applications/llama_3.2_1b/src/block/gqa.py
@@ -166,15 +166,15 @@ class GroupedQueryAttention(nn.Module):
             x_flat = x.reshape(1, -1)  # Shape: (1, d_in)
             input_dtype = x.dtype
 
-            queries_flat = self.aie_query_gemv(None, x_flat)
+            queries_flat = self.aie_query_gemv(x_flat)
             queries = queries_flat.reshape(b, num_tokens, self.d_out).to(input_dtype)
 
-            keys_flat = self.aie_key_gemv(None, x_flat)
+            keys_flat = self.aie_key_gemv(x_flat)
             keys = keys_flat.reshape(
                 b, num_tokens, self.num_kv_groups * self.head_dim
             ).to(input_dtype)
 
-            values_flat = self.aie_value_gemv(None, x_flat)
+            values_flat = self.aie_value_gemv(x_flat)
             values = values_flat.reshape(
                 b, num_tokens, self.num_kv_groups * self.head_dim
             ).to(input_dtype)
@@ -384,7 +384,7 @@ class GroupedQueryAttention(nn.Module):
         # Choose output projection based on phase
         if self.cfg["use_kv_cache"] and is_decode and self.cfg["use_aie_gemv"]:
             context_vec_flat = context_vec.reshape(1, -1)
-            output_flat = self.aie_out_proj_gemv(None, context_vec_flat)
+            output_flat = self.aie_out_proj_gemv(context_vec_flat)
             context_vec = output_flat.reshape(b, num_tokens, self.d_out).to(input_dtype)
         elif self.cfg["use_aie_attn_projection_gemm"]:
             context_vec_flat = context_vec.reshape(-1, self.d_out)

--- a/applications/llama_3.2_1b/src/block/gqa.py
+++ b/applications/llama_3.2_1b/src/block/gqa.py
@@ -19,6 +19,8 @@ from src.operator.aie_gemv import AIEGEMV
 
 from torchtune.modules import KVCache
 
+from ..utils import assign
+
 
 class GroupedQueryAttention(nn.Module):
     def __init__(
@@ -121,6 +123,7 @@ class GroupedQueryAttention(nn.Module):
             aie_gemv_config = {
                 "num_columns": 1,
                 "is_mv": False,
+                "use_static_weight": True,
             }
             self.aie_query_gemv = AIEGEMV(M=d_out, K=d_in, **aie_gemv_config)
             kv_out_dim = num_kv_groups * self.head_dim
@@ -163,15 +166,15 @@ class GroupedQueryAttention(nn.Module):
             x_flat = x.reshape(1, -1)  # Shape: (1, d_in)
             input_dtype = x.dtype
 
-            queries_flat = self.aie_query_gemv(self.W_query.weight.T, x_flat)
+            queries_flat = self.aie_query_gemv(None, x_flat)
             queries = queries_flat.reshape(b, num_tokens, self.d_out).to(input_dtype)
 
-            keys_flat = self.aie_key_gemv(self.W_key.weight.T, x_flat)
+            keys_flat = self.aie_key_gemv(None, x_flat)
             keys = keys_flat.reshape(
                 b, num_tokens, self.num_kv_groups * self.head_dim
             ).to(input_dtype)
 
-            values_flat = self.aie_value_gemv(self.W_value.weight.T, x_flat)
+            values_flat = self.aie_value_gemv(None, x_flat)
             values = values_flat.reshape(
                 b, num_tokens, self.num_kv_groups * self.head_dim
             ).to(input_dtype)
@@ -381,9 +384,7 @@ class GroupedQueryAttention(nn.Module):
         # Choose output projection based on phase
         if self.cfg["use_kv_cache"] and is_decode and self.cfg["use_aie_gemv"]:
             context_vec_flat = context_vec.reshape(1, -1)
-            output_flat = self.aie_out_proj_gemv(
-                self.out_proj.weight.T, context_vec_flat
-            )
+            output_flat = self.aie_out_proj_gemv(None, context_vec_flat)
             context_vec = output_flat.reshape(b, num_tokens, self.d_out).to(input_dtype)
         elif self.cfg["use_aie_attn_projection_gemm"]:
             context_vec_flat = context_vec.reshape(-1, self.d_out)
@@ -393,3 +394,31 @@ class GroupedQueryAttention(nn.Module):
             context_vec = self.out_proj(context_vec)
 
         return context_vec
+
+    def assign_weights(self, l, w_query, w_key, w_value, w_out_proj):
+        if self.cfg["use_kv_cache"] and self.cfg["use_aie_gemv"]:
+            self.aie_query_gemv.weight = w_query
+            self.aie_key_gemv.weight = w_key
+            self.aie_value_gemv.weight = w_value
+            self.aie_out_proj_gemv.weight = w_out_proj
+
+        self.W_query.weight = assign(
+            self.W_query.weight,
+            w_query,
+            f"model.layers.{l}.self_attn.q_proj.weight",
+        )
+        self.W_key.weight = assign(
+            self.W_key.weight,
+            w_key,
+            f"model.layers.{l}.self_attn.k_proj.weight",
+        )
+        self.W_value.weight = assign(
+            self.W_value.weight,
+            w_value,
+            f"model.layers.{l}.self_attn.v_proj.weight",
+        )
+        self.out_proj.weight = assign(
+            self.out_proj.weight,
+            w_out_proj,
+            f"model.layers.{l}.self_attn.o_proj.weight",
+        )

--- a/applications/llama_3.2_1b/src/block/transformer.py
+++ b/applications/llama_3.2_1b/src/block/transformer.py
@@ -10,6 +10,8 @@ import torch
 import torch.nn as nn
 from src.block.gqa import GroupedQueryAttention
 from src.block.feed_forward import FeedForward
+from src.operator.aie_rms_norm import AIERMSNorm
+from src.operator.aie_elementwise_add import AIEElementwiseAdd
 
 
 class TransformerBlock(nn.Module):
@@ -38,8 +40,6 @@ class TransformerBlock(nn.Module):
         )
 
         if self.cfg["use_aie_norm1"]:
-            from src.operator.aie_rms_norm import AIERMSNorm
-
             self.norm1 = AIERMSNorm(
                 emb_dim=cfg["emb_dim"],
                 eps=1e-5,
@@ -51,8 +51,6 @@ class TransformerBlock(nn.Module):
             self.norm1 = nn.RMSNorm(cfg["emb_dim"], eps=1e-5, dtype=cfg["dtype"])
 
         if self.cfg["use_aie_norm2"]:
-            from src.operator.aie_rms_norm import AIERMSNorm
-
             self.norm2 = AIERMSNorm(
                 emb_dim=cfg["emb_dim"],
                 eps=1e-5,
@@ -64,8 +62,6 @@ class TransformerBlock(nn.Module):
             self.norm2 = nn.RMSNorm(cfg["emb_dim"], eps=1e-5, dtype=cfg["dtype"])
 
         if self.cfg["use_aie_residual"]:
-            from src.operator.aie_elementwise_add import AIEElementwiseAdd
-
             if self.cfg["use_kv_cache"]:
                 max_prefill_size = prompt_length * cfg["emb_dim"]
             else:
@@ -103,10 +99,7 @@ class TransformerBlock(nn.Module):
             is_decode_with_kv = False
 
         shortcut = x
-        if self.cfg["use_aie_norm1"]:
-            x = self.norm1(x, self.norm1.weight)
-        else:
-            x = self.norm1(x)
+        x = self.norm1(x)
 
         x = self.att(x, mask, angles, input_pos)
 
@@ -120,11 +113,7 @@ class TransformerBlock(nn.Module):
 
         # Shortcut connection for feed-forward block
         shortcut = x
-        if self.cfg["use_aie_norm2"]:
-            x = self.norm2(x, self.norm2.weight)
-        else:
-            x = self.norm2(x)
-
+        x = self.norm2(x)
         x = self.ff(x)
 
         if self.cfg["use_aie_residual"]:

--- a/applications/llama_3.2_1b/src/model_with_json.py
+++ b/applications/llama_3.2_1b/src/model_with_json.py
@@ -37,6 +37,7 @@ config_options = {
     "use_aie_ffn_gemm":             (bool,              False,         "[FFN] GEMM"),
     "use_aie_ffn_mul":              (bool,              False,         "[FFN] Elementwise Mul"),
     "use_aie_ffn_silu":             (bool,              False,         "[FFN] SiLU"),
+    "use_aie_ffn_swiglu":           (bool,              False,         "[FFN] Runlist-based SwiGLU"),
     "use_aie_residual":             (bool,              False,         "[Transformer] Residual Addition"),
     "use_aie_norm1":                (bool,              False,         "[Transformer] Pre Norm"),
     "use_aie_norm2":                (bool,              False,         "[Transformer] Post Norm"),
@@ -184,10 +185,7 @@ class Llama3ModelWithJSONConfig(nn.Module):
         for block in self.trf_blocks:
             x = block(x, mask, self.angles, input_pos)
 
-        if self.cfg.get("use_aie_final_norm", False):
-            x = self.final_norm(x, self.final_norm.weight)
-        else:
-            x = self.final_norm(x)
+        x = self.final_norm(x)
 
         logits = self.out_head(x.to(self.cfg["dtype"]))
 

--- a/applications/llama_3.2_1b/src/model_with_json.py
+++ b/applications/llama_3.2_1b/src/model_with_json.py
@@ -37,7 +37,6 @@ config_options = {
     "use_aie_ffn_gemm":             (bool,              False,         "[FFN] GEMM"),
     "use_aie_ffn_mul":              (bool,              False,         "[FFN] Elementwise Mul"),
     "use_aie_ffn_silu":             (bool,              False,         "[FFN] SiLU"),
-    "use_aie_ffn_swiglu":           (bool,              False,         "[FFN] Runlist-based SwiGLU"),
     "use_aie_residual":             (bool,              False,         "[Transformer] Residual Addition"),
     "use_aie_norm1":                (bool,              False,         "[Transformer] Pre Norm"),
     "use_aie_norm2":                (bool,              False,         "[Transformer] Post Norm"),

--- a/applications/llama_3.2_1b/src/operator/aie_base.py
+++ b/applications/llama_3.2_1b/src/operator/aie_base.py
@@ -18,6 +18,7 @@ class AIEOperatorBase(ABC):
     """Base class for AIE-accelerated operations"""
 
     registered_operators = []
+    static_data_pool = {}  # Map bytes -> number of users
 
     # Global configuration
     device_manager = AIEDeviceManager()
@@ -44,16 +45,31 @@ class AIEOperatorBase(ABC):
         page_sz = 4096
         get_pool_sz = lambda x: (x + page_sz - 1) // page_sz * page_sz
 
+        # Allocate static buffers first
+        for buffer_data in cls.static_data_pool:
+            logging.debug(
+                f"Allocating static buffer with size {len(buffer_data)} bytes."
+            )
+            bo = pyxrt.bo(
+                cls.device_manager.device,
+                len(buffer_data),
+                pyxrt.bo.host_only,
+                0x10000,
+            )
+            bo.write(np.frombuffer(buffer_data, dtype=np.uint8), 0)
+            cls.static_data_pool[buffer_data] = bo
+
         for op in cls.registered_operators:
             logging.info(f"Preparing runtime for AIE operator: {op.__class__.__name__}")
 
+            # Set up for each kernel
             for kernel_name, (xclbin, xclbin_kernel_name, insts) in op.kernels.items():
                 context, xrt_kernel = cls.device_manager.get_context_and_kernel(
                     str(xclbin.path), xclbin_kernel_name
                 )
                 with open(str(insts.path), "rb") as f:
                     instructions = np.frombuffer(f.read(), dtype=np.uint32)
-                logging.info(
+                logging.debug(
                     f"Allocating instruction buffer for {len(instructions)} instructions."
                 )
                 insts_bo = pyxrt.bo(
@@ -75,6 +91,9 @@ class AIEOperatorBase(ABC):
             conflicting_buffers = {}  # map buffer -> {set of conflicting buffers}
             for kernel, *args in op.runlist:
                 for arg in args:
+                    if arg in op.buffer_static_data:
+                        # Static buffers never conflict
+                        continue
                     # Conflict only exists if buffers are in the same size pool
                     pool_sz = get_pool_sz(op.buffers[arg])
                     conflicting_args = {
@@ -86,6 +105,11 @@ class AIEOperatorBase(ABC):
 
             buffer_allocations = {}  # map buffer -> (key into bo_pools, list index)
             for buffer_name, buffer_min_size in op.buffers.items():
+                if buffer_name in op.buffer_static_data:
+                    # Static buffers are allocated separately
+                    static_data = op.buffer_static_data[buffer_name]
+                    op.buffer_bos[buffer_name] = cls.static_data_pool[static_data]
+                    continue
                 alloc_pool = get_pool_sz(buffer_min_size)
                 alloc_idx = 0
                 for conflict in conflicting_buffers.get(buffer_name, set()):
@@ -107,10 +131,35 @@ class AIEOperatorBase(ABC):
                 buffer_allocations[buffer_name] = (alloc_pool, alloc_idx)
                 op.buffer_bos[buffer_name] = bo_pools[alloc_pool][alloc_idx]
 
+            # Runlist setup
+            _, (first_xclbin, first_xclbin_kernel_name, _) = next(
+                iter(op.kernels.items())
+            )
+            context, _ = cls.device_manager.get_context_and_kernel(
+                str(first_xclbin.path), first_xclbin_kernel_name
+            )
+            op.xrt_runlist = pyxrt.runlist(context)
+            for i, (kernel_name, *buffer_args) in enumerate(op.runlist):
+                this_context, xrt_kernel, insts_bo, insts_len = op.xrt_kernels[
+                    kernel_name
+                ]
+                assert this_context == context
+                opcode = 3
+                run = pyxrt.run(xrt_kernel)
+                run.set_arg(0, opcode)
+                run.set_arg(1, insts_bo)
+                run.set_arg(2, insts_len)
+                for j, buffer_arg in enumerate(buffer_args):
+                    run.set_arg(j + 3, op.buffer_bos[buffer_arg])
+                op.xrt_runlist.add(run)
+
         bo_count = sum(len(pool) for pool in bo_pools.values())
         bo_footprint = sum(len(pool) * pool_sz for pool_sz, pool in bo_pools.items())
         logging.info(
-            f"Allocated {bo_count} total buffer objects with a total memory footprint of {bo_footprint} bytes."
+            f"Allocated {bo_count} total buffer objects with a total memory footprint of {bo_footprint//1024//1024} MiB."
+        )
+        logging.info(
+            f"Allocated {len(cls.static_data_pool)} static buffers with a total memory footprint of {sum(len(data) for data in cls.static_data_pool)//1024//1024} MiB."
         )
 
     def __init__(self):
@@ -119,6 +168,7 @@ class AIEOperatorBase(ABC):
         )  # CompilationArtifact objects are globally uniqued, so any overlapping elements of this list will be shared with other operators and will be cached.
         self.kernels = {}  # Name -> (xclbin_path, xclbin_kernel_name, insts_path)
         self.buffers = {}  # Name -> required buffer size in bytes
+        self.buffer_static_data = {}
         self.runlist = (
             []
         )  # List of (kernel_name, buffers_name, buffer_name...), will be executed in sequence
@@ -127,7 +177,8 @@ class AIEOperatorBase(ABC):
         self.buffer_bos = {}  # Buffer name -> buffer object
         self.xrt_kernels = (
             {}
-        )  # Kernel name -> (XRT kernel object, instruction sequence, instruction buffer object, instruction length)
+        )  # Kernel name -> (XRT context, XRT kernel object, instruction buffer object, instruction length)
+        self.xrt_runlist = None
 
         self.registered_operators.append(self)
 
@@ -144,9 +195,21 @@ class AIEOperatorBase(ABC):
         assert name not in self.kernels
         self.kernels[name] = (xclbin_artifact, xclbin_kernel_name, insts_artifact)
 
-    def add_buffer(self, name, count, dtype=bfloat16):
+    def add_buffer(self, name, count, dtype=bfloat16, static_data=None):
         assert name not in self.buffers
         self.buffers[name] = count * np.dtype(dtype).itemsize
+        if static_data is not None:
+            assert (
+                static_data.nbytes <= self.buffers[name]
+            ), f"Static data for buffer {name} exceeds allocated size."
+            static_data_bytes = static_data.flatten().view(np.uint8).tobytes()
+            if static_data_bytes not in self.static_data_pool:
+                self.static_data_pool[static_data_bytes] = None
+            # The actual key in self.static_data_pool may be a different object than static_data_bytes (even if they compare equal).
+            # Since these may be large buffers, we want to reuse a reference to the key rather than recreate the object in self.buffer_static_data.
+            self.buffer_static_data[name] = next(
+                k for k, v in self.static_data_pool.items() if k == static_data_bytes
+            )
 
     def add_to_runlist(self, kernel_name, *args):
         if kernel_name not in self.kernels:
@@ -171,6 +234,8 @@ class AIEOperatorBase(ABC):
 
     def write_buffer(self, buffer_name, numpy_array):
         """Write buffer from a numpy array into a XRT buffer object"""
+        if buffer_name in self.buffer_static_data:
+            raise RuntimeError(f"Cannot write to static buffer: {buffer_name}")
         self.get_bo(buffer_name).write(numpy_array.flatten().view(np.uint8), 0)
 
     @abstractmethod
@@ -198,9 +263,10 @@ class AIEOperatorBase(ABC):
                 self.build_dir, self.peano_dir, self.mlir_aie_dir
             ),
         ]
-        logging.info(
-            f"Compiling AIE operator {self.__class__.__name__} with {len(work_list)} artifacts: {', '.join(str(artifact.path.name) for artifact in work_list)}"
-        )
+        if work_list:
+            logging.info(
+                f"Compiling {len(work_list)} new artifacts for AIE operator {self.__class__.__name__}: {', '.join(str(artifact.path.name) for artifact in work_list)}"
+            )
         comp.compile(compilation_rules, work_list)
 
     def add_artifacts(self, artifacts):
@@ -219,21 +285,20 @@ class AIEOperatorBase(ABC):
             todo.extend(artifact.depends)
 
     def run_runlist(self):
-        for i, (kernel_name, *buffer_args) in enumerate(self.runlist):
-            context, xrt_kernel, insts_bo, insts_len = self.xrt_kernels[kernel_name]
-            insts_bo.sync(pyxrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
-            bos = [self.buffer_bos[buffer_arg] for buffer_arg in buffer_args]
-            for bo in bos:
-                bo.sync(pyxrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
-            opcode = 3
-            run = xrt_kernel(opcode, insts_bo, insts_len, *bos)
-            result = run.wait()
-            if result != pyxrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED:
-                raise RuntimeError(
-                    f"Kernel {kernel_name} did not complete correctly: {result}"
-                )
-            for bo in bos:
-                bo.sync(pyxrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
+        bos = set(
+            self.buffer_bos[buffer_arg]
+            for _, *buffer_args in self.runlist
+            for buffer_arg in buffer_args
+        )
+        insts_bos = set(
+            self.xrt_kernels[kernel_name][2] for (kernel_name, *_) in self.runlist
+        )
+        for bo in bos | insts_bos:
+            bo.sync(pyxrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
+        self.xrt_runlist.execute()
+        self.xrt_runlist.wait()
+        for bo in bos:
+            bo.sync(pyxrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE)
 
 
 class AIEOperatorConstraintError(RuntimeError):

--- a/applications/llama_3.2_1b/src/operator/aie_gemm.py
+++ b/applications/llama_3.2_1b/src/operator/aie_gemm.py
@@ -82,19 +82,10 @@ class AIEGEMM(AIEOperatorBase):
 
     def set_up(self):
         # Describe required artifacts (xclbin, insts.bin)
-        # file_name_tile_base = f"{self.tile_m}x{self.tile_k}x{self.tile_n}"
+        file_name_tile_base = f"{self.tile_m}x{self.tile_k}x{self.tile_n}"
         file_name_total_base = (
             f"{self.M}x{self.K}x{self.N}_{self.tile_m}x{self.tile_k}x{self.tile_n}"
         )
-        # FIXME: We should be able to reuse the same xclbin for same tile
-        # sizes, only swapping out the instruction sequence for different
-        # problem sizes. However, there seem to be cases where this does
-        # not work and the GEMM appears to be misconfigured for the wrong
-        # size (resulting in a timeout when trying to run it). Perhaps
-        # XRT is caching something, or something is wrong with the run-
-        # time parameter (synchronization)? For now, create separate
-        # xclbins for each problem size.
-        file_name_tile_base = file_name_total_base
         xclbin_kernel_name = f"gemm_{file_name_tile_base}"
         kernel_flags = [
             f"-DDIM_M={self.tile_m}",
@@ -133,8 +124,16 @@ class AIEGEMM(AIEOperatorBase):
             requires_context=True,
         )
 
+        # FIXME: We should be able to reuse the same xclbin for same tile
+        # sizes, only swapping out the instruction sequence for different
+        # problem sizes. However, there seem to be cases where this does
+        # not work and the GEMM appears to be misconfigured for the wrong
+        # size (resulting in a timeout when trying to run it). Perhaps
+        # XRT is caching something, or something is wrong with the run-
+        # time parameter (synchronization)? For now, create separate
+        # xclbins for each problem size.
         xclbin_artifact = XclbinArtifact.new(
-            f"gemm_{file_name_tile_base}.xclbin",
+            f"gemm_{file_name_total_base}.xclbin",
             depends=[
                 mlir_artifact,
                 KernelArchiveArtifact.new(

--- a/applications/llama_3.2_1b/src/operator/aie_gemm.py
+++ b/applications/llama_3.2_1b/src/operator/aie_gemm.py
@@ -82,10 +82,19 @@ class AIEGEMM(AIEOperatorBase):
 
     def set_up(self):
         # Describe required artifacts (xclbin, insts.bin)
-        file_name_tile_base = f"{self.tile_m}x{self.tile_k}x{self.tile_n}"
+        # file_name_tile_base = f"{self.tile_m}x{self.tile_k}x{self.tile_n}"
         file_name_total_base = (
             f"{self.M}x{self.K}x{self.N}_{self.tile_m}x{self.tile_k}x{self.tile_n}"
         )
+        # FIXME: We should be able to reuse the same xclbin for same tile
+        # sizes, only swapping out the instruction sequence for different
+        # problem sizes. However, there seem to be cases where this does
+        # not work and the GEMM appears to be misconfigured for the wrong
+        # size (resulting in a timeout when trying to run it). Perhaps
+        # XRT is caching something, or something is wrong with the run-
+        # time parameter (synchronization)? For now, create separate
+        # xclbins for each problem size.
+        file_name_tile_base = file_name_total_base
         xclbin_kernel_name = f"gemm_{file_name_tile_base}"
         kernel_flags = [
             f"-DDIM_M={self.tile_m}",

--- a/applications/llama_3.2_1b/src/operator/aie_gemm.py
+++ b/applications/llama_3.2_1b/src/operator/aie_gemm.py
@@ -26,6 +26,7 @@ class AIEGEMM(AIEOperatorBase):
         M,
         K,
         N,
+        use_static_weight=False,
         num_columns=8,
         tile_m=64,
         tile_k=64,
@@ -62,6 +63,11 @@ class AIEGEMM(AIEOperatorBase):
         self.round_conv_even = round_conv_even
         self.n_aie_rows = 4
         self.num_columns = num_columns
+        self.weight = (
+            None
+            if not use_static_weight
+            else torch.zeros((K, N), dtype=torch.bfloat16).T
+        )
 
         # The operator's M, K, N represent what the NPU operator supports.
         # Calls to forward() may supply matrices of different sizes, and the
@@ -150,26 +156,33 @@ class AIEGEMM(AIEOperatorBase):
         self.add_artifacts(artifacts)
 
         # Describe runtime components
+        # The static weights might not yet be loaded upon initialization; therefore, the provided self.static_weights field is a callback that provides the weights at set-up time.
+        static_weights = None
+        if self.weight is not None:
+            static_weights = self.weight.T
+            if isinstance(static_weights, torch.Tensor):
+                static_weights = torch_to_numpy(static_weights)
         self.add_kernel(
             "gemm", xclbin_artifact, xclbin_artifact.kernel_name, insts_artifact
         )
         self.add_buffer("A", self.M * self.K)
-        self.add_buffer("B", self.K * self.N)
+        self.add_buffer("B", self.K * self.N, static_data=static_weights)
         self.add_buffer("C", self.M * self.N)
         self.add_to_runlist("gemm", "A", "B", "C")
 
-    def forward(self, A, B):
+    def forward(self, A, B=None):
         """Forward pass through GEMM operation: C = A @ B"""
-        expected_output_shape = A.shape[:-1] + (B.shape[-1],)
+        B_shape = B.shape if B is not None else self.weight.T.shape
+        expected_output_shape = A.shape[:-1] + (B_shape[-1],)
 
         # Remove batch dimension, if any
         if len(A.shape) > 2:
             A = A.view(-1, A.shape[-1])
-        if len(B.shape) > 2:
-            B = B.view(-1, B.shape[-1])
+        if B is not None and len(B.shape) > 2:
+            B = B.view(-1, B_shape[-1])
 
         M, K = A.shape
-        K2, N = B.shape
+        K2, N = B_shape
 
         applicable = (
             K == K2
@@ -181,7 +194,10 @@ class AIEGEMM(AIEOperatorBase):
             raise AIEOperatorConstraintError("AIEGEMM: incompatible tensor shape(s)")
 
         A_padded = self._pad_A(torch_to_numpy(A))
-        B_padded = self._pad_B(torch_to_numpy(B))
+        if B is not None:
+            B_padded = self._pad_B(torch_to_numpy(B))
+        else:
+            B_padded = None
 
         logging.debug(
             f"Executing GEMM for dimensions M={M}, K={K}, N={N} using NPU operator with M={self.M}, K={self.N}, N={self.N}"
@@ -232,10 +248,10 @@ class AIEGEMM(AIEOperatorBase):
             B_padded[:K, :N] = B_np
         return B_padded
 
-    def _execute_aie_operation(self, A_np, B_np):
+    def _execute_aie_operation(self, A_np, B_np=None):
         """Execute GEMM operation on AIE hardware"""
         M, K = A_np.shape
-        K2, N = B_np.shape
+        K2, N = B_np.shape if B_np is not None else self.weight.T.shape
 
         # If M is larger than kernel supports, split large GEMMs with many rows
         # into multiple invocations of the kernel. This is only supported for
@@ -244,8 +260,9 @@ class AIEGEMM(AIEOperatorBase):
         assert K == K2 and K == self.K
         assert N == self.N
 
-        self.write_buffer("B", B_np)
         self.write_buffer("A", A_np)
+        if B_np is not None:
+            self.write_buffer("B", B_np)
         self.run_runlist()
         result_np = self.read_buffer("C", shape=(M, N), dtype=bfloat16)
 

--- a/applications/llama_3.2_1b/src/operator/aie_gemv.py
+++ b/applications/llama_3.2_1b/src/operator/aie_gemv.py
@@ -107,7 +107,7 @@ class AIEGEMV(AIEOperatorBase):
         self.add_buffer("output", self.M)
         self.add_to_runlist("gemv", "matrix", "vector", "output")
 
-    def forward(self, matrix, vector):
+    def forward(self, vector, matrix=None):
         """Forward pass through GEMV operation
 
         Args:

--- a/applications/llama_3.2_1b/src/operator/aie_gemv.py
+++ b/applications/llama_3.2_1b/src/operator/aie_gemv.py
@@ -20,13 +20,28 @@ from ..utils import torch_to_numpy, numpy_to_torch
 class AIEGEMV(AIEOperatorBase):
     """AIE-accelerated General Matrix-Vector/Vector-Matrix Multiplication layer"""
 
-    def __init__(self, M, K, num_columns=1, tile_size=1, is_mv=True):
+    def __init__(
+        self,
+        M,
+        K,
+        num_columns=1,
+        num_channels=2,
+        tile_size=1,
+        is_mv=True,
+        use_static_weight=False,
+    ):
 
-        self.M = M
-        self.K = K
+        self.M = M  # matrix rows  (if is_mv=False, matrix columns)
+        self.K = K  # matrix columns, vector rows  (if is_mv=False, matrix rows, vector columns)
         self.num_columns = num_columns
         self.tile_size = tile_size
         self.is_mv = is_mv
+        if use_static_weight:
+            self.weight = torch.zeros(
+                (M, K) if is_mv else (K, M), dtype=torch.bfloat16
+            ).T  # weights are stored col-major/transposed
+        else:
+            self.weight = None
 
         # For compatibility with my_matvec parameters
         self.m = self.tile_size
@@ -73,10 +88,21 @@ class AIEGEMV(AIEOperatorBase):
 
         # Runtime Setup
         # ---
+        static_weights = None
+        if self.weight is not None:
+            # Kernel expects row-major weights, so might need to transpose;
+            # also might need to transpose if is_mv
+            if self.is_mv:
+                static_weights = self.weight.T
+            else:
+                # Double transpose cancels out
+                static_weights = self.weight
+            if isinstance(static_weights, torch.Tensor):
+                static_weights = torch_to_numpy(static_weights)
         self.add_kernel(
             "gemv", xclbin_artifact, xclbin_artifact.kernel_name, insts_artifact
         )
-        self.add_buffer("matrix", self.M * self.K)
+        self.add_buffer("matrix", self.M * self.K, static_data=static_weights)
         self.add_buffer("vector", self.K)
         self.add_buffer("output", self.M)
         self.add_to_runlist("gemv", "matrix", "vector", "output")
@@ -92,16 +118,32 @@ class AIEGEMV(AIEOperatorBase):
         Returns:
             Output vector of shape (..., M) for MV or (..., K) for VM
         """
-        # Handle 3D tensor shapes like (1, 1, emb_dim) by getting the last dimensions
-        matrix_rows = matrix.shape[-2]
-        matrix_cols = matrix.shape[-1]
+
+        # Flatten batch dimensions if needed
+        if matrix is not None:
+            matrix = matrix.reshape(*matrix.shape[-2:])
+        vector = vector.reshape(*vector.shape[-1:])
+
+        # For vector-matrix, we'll transpose the matrix internally
+        if matrix is not None and not self.is_mv:
+            # Transpose the matrix for vector-matrix multiplication
+            # (if using static weights, the matrix is already transposed once at setup if needed)
+            matrix = matrix.transpose(-2, -1)
+
+        if matrix is not None:
+            matrix_rows = matrix.shape[-2]
+            matrix_cols = matrix.shape[-1]
+        else:
+            matrix_rows = self.M
+            matrix_cols = self.K
+
         vector_size = vector.shape[-1]
 
         applicable = (
-            vector_size == (matrix_cols if self.is_mv else matrix_rows)
-            and matrix_rows == (self.M if self.is_mv else self.K)
-            and matrix_cols == (self.K if self.is_mv else self.M)
-            and matrix.dtype == torch.bfloat16
+            matrix_cols == vector_size
+            and matrix_rows == self.M
+            and matrix_cols == self.K
+            and (matrix is None or matrix.dtype == torch.bfloat16)
             and vector.dtype == torch.bfloat16
         )
         if not applicable:
@@ -109,73 +151,11 @@ class AIEGEMV(AIEOperatorBase):
                 "AIEElementwiseAdd: incompatible tensor shape(s)"
             )
 
-        # For vector-matrix, we'll transpose the matrix internally
-        if not self.is_mv:
-            # Transpose the matrix for vector-matrix multiplication
-            matrix = matrix.transpose(-2, -1)
-
-        # Ensure vector is 1D for the last dimension
-        if vector.dim() > 1 and vector.shape[-1] == 1:
-            vector = vector.squeeze(-1)
-
-        return self._execute_aie_operation(matrix, vector)
-
-    def _execute_aie_operation(self, matrix, vector):
-        """Execute matrix-vector multiplication on AIE hardware"""
-
-        # Store original shapes
-        original_matrix_shape = matrix.shape
-        original_vector_shape = vector.shape
-
-        # Flatten batch dimensions if needed
-        if len(matrix.shape) > 2:
-            matrix = matrix.view(-1, matrix.shape[-2], matrix.shape[-1])
-        if len(vector.shape) > 1:
-            vector = vector.view(-1, vector.shape[-1])
-
-        batch_size = matrix.shape[0] if len(matrix.shape) > 2 else 1
-
-        # Process each batch element
-        results = []
-        for i in range(batch_size):
-            if batch_size > 1:
-                matrix_batch = matrix[i]
-                vector_batch = vector[i] if len(vector.shape) > 1 else vector
-            else:
-                matrix_batch = matrix
-                vector_batch = vector
-
-            result = self._process_single_gemv(matrix_batch, vector_batch)
-            results.append(result)
-
-        # Concatenate results
-        if len(results) > 1:
-            result = torch.stack(results, dim=0)
-        else:
-            result = results[0]
-
-        # Restore original shape if needed
-        if len(original_matrix_shape) > 2:
-            if self.is_mv:
-                result_shape = original_matrix_shape[:-2] + (self.M,)
-            else:
-                result_shape = original_matrix_shape[:-2] + (self.K,)
-            result = result.view(result_shape)
-
-        return result
-
-    def _process_single_gemv(self, matrix_data, vector_data):
-        """Process a single matrix-vector multiplication through the AIE kernel"""
-        # Ensure inputs are 2D and 1D respectively
-        if matrix_data.dim() == 3:
-            matrix_data = matrix_data.squeeze(0)
-        if vector_data.dim() == 2:
-            vector_data = vector_data.squeeze(0)
-
-        matrix_np = torch_to_numpy(matrix_data.contiguous())
-        vector_np = torch_to_numpy(vector_data.contiguous())
-
-        self.write_buffer("matrix", matrix_np)
+        vector_np = torch_to_numpy(vector)
+        if matrix is not None:
+            matrix_np = torch_to_numpy(matrix)
+            # If matrix is none, we are using static weights that have already been written to the buffer
+            self.write_buffer("matrix", matrix_np)
         self.write_buffer("vector", vector_np)
         self.run_runlist()
         result = self.read_buffer_as_torch("output", (self.M,))

--- a/applications/llama_3.2_1b/src/operator/aie_rms_norm.py
+++ b/applications/llama_3.2_1b/src/operator/aie_rms_norm.py
@@ -80,16 +80,20 @@ class AIERMSNorm(AIEOperatorBase):
         self.add_artifacts(artifacts)
 
         # Runtime setup
+        static_weights = None
+        if self.weight is not None:
+            static_weights = torch_to_numpy(self.weight)
+
         total_elements = self.emb_dim * self.num_columns * self.num_channels
         self.add_buffer("input1", total_elements)
-        self.add_buffer("input2", total_elements)
+        self.add_buffer("input2", total_elements, static_data=static_weights)
         self.add_buffer("output", total_elements)
         self.add_kernel(
             "eltwise_mul", xclbin_artifact, xclbin_artifact.kernel_name, insts_artifact
         )
         self.add_to_runlist("eltwise_mul", "input1", "input2", "output")
 
-    def forward(self, x, y):
+    def forward(self, x, y=None):
         """Forward pass through RMS normalization"""
         applicable = (
             len(x.shape) >= 2
@@ -101,7 +105,7 @@ class AIERMSNorm(AIEOperatorBase):
 
         return self._execute_aie_operation(x, y)
 
-    def _execute_aie_operation(self, x, y):
+    def _execute_aie_operation(self, x, y=None):
         """Execute RMS normalization on AIE hardware"""
 
         original_shape = x.shape
@@ -144,18 +148,24 @@ class AIERMSNorm(AIEOperatorBase):
 
         return result
 
-    def _process_batch(self, batch_data, weight_data):
+    def _process_batch(self, batch_data, weight_data=None):
         """Process a batch of sequences through the AIE kernel"""
         batch_flat = batch_data.view(-1)
         input_data = torch_to_numpy(batch_flat)
-        weights_data = torch_to_numpy(weight_data)
+        if weight_data is not None:
+            weights_data = torch_to_numpy(weight_data)
 
         # Calculate buffer sizes for the batch
         input_size = input_data.nbytes
 
         # Write data to buffers
         self.write_buffer("input1", input_data)
-        self.write_buffer("input2", weights_data)
+        if weight_data is not None:
+            self.write_buffer("input2", weights_data)
+        else:
+            assert (
+                self.weight is not None
+            ), "Weights must be provided either as input or during initialization."
         # Initialize output buffer
         test_pattern = np.zeros(len(input_data), dtype=bfloat16)
         self.write_buffer("output", test_pattern)

--- a/applications/llama_3.2_1b/src/utils.py
+++ b/applications/llama_3.2_1b/src/utils.py
@@ -118,25 +118,12 @@ def load_weights_into_llama(model, param_config, params):
     for l in range(param_config["n_layers"]):
 
         # Load attention weights
-        model.trf_blocks[l].att.W_query.weight = assign(
-            model.trf_blocks[l].att.W_query.weight,
+        model.trf_blocks[l].att.assign_weights(
+            l,
             params[f"model.layers.{l}.self_attn.q_proj.weight"],
-            f"model.layers.{l}.self_attn.q_proj.weight",
-        )
-        model.trf_blocks[l].att.W_key.weight = assign(
-            model.trf_blocks[l].att.W_key.weight,
             params[f"model.layers.{l}.self_attn.k_proj.weight"],
-            f"model.layers.{l}.self_attn.k_proj.weight",
-        )
-        model.trf_blocks[l].att.W_value.weight = assign(
-            model.trf_blocks[l].att.W_value.weight,
             params[f"model.layers.{l}.self_attn.v_proj.weight"],
-            f"model.layers.{l}.self_attn.v_proj.weight",
-        )
-        model.trf_blocks[l].att.out_proj.weight = assign(
-            model.trf_blocks[l].att.out_proj.weight,
             params[f"model.layers.{l}.self_attn.o_proj.weight"],
-            f"model.layers.{l}.self_attn.o_proj.weight",
         )
         model.trf_blocks[l].norm1.weight = assign(
             model.trf_blocks[l].norm1.weight,
@@ -145,20 +132,11 @@ def load_weights_into_llama(model, param_config, params):
         )
 
         # Load FeedForward weights
-        model.trf_blocks[l].ff.fc1.weight = assign(
-            model.trf_blocks[l].ff.fc1.weight,
-            params[f"model.layers.{l}.mlp.gate_proj.weight"],
-            f"model.layers.{l}.mlp.gate_proj.weight",
-        )
-        model.trf_blocks[l].ff.fc2.weight = assign(
-            model.trf_blocks[l].ff.fc2.weight,
-            params[f"model.layers.{l}.mlp.up_proj.weight"],
-            f"model.layers.{l}.mlp.up_proj.weight",
-        )
-        model.trf_blocks[l].ff.fc3.weight = assign(
-            model.trf_blocks[l].ff.fc3.weight,
-            params[f"model.layers.{l}.mlp.down_proj.weight"],
-            f"model.layers.{l}.mlp.down_proj.weight",
+        model.trf_blocks[l].ff.assign_weights(
+            l,
+            fc1=params[f"model.layers.{l}.mlp.gate_proj.weight"],
+            fc2=params[f"model.layers.{l}.mlp.up_proj.weight"],
+            fc3=params[f"model.layers.{l}.mlp.down_proj.weight"],
         )
         model.trf_blocks[l].norm2.weight = assign(
             model.trf_blocks[l].norm2.weight,


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

Builds on #8.

## Changed
- Weights get dedicated buffer allocations for each operator, such that weights do not need to be copied on each operator invocation.


## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
3. [x] All checks are passing.
