### PR TITLE
Remove environment variables from MLIR Python extras install

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If starting from `Ubuntu 24.04` you may need to update the Linux kernel to 6.11+
 
 1. Install required Python packages (from requirements.txt):
    ```bash
-   MLIR_PYTHON_EXTRAS_SET_VERSION="0.0.8.3" HOST_MLIR_PYTHON_PACKAGE_PREFIX="aie" pip install -r requirements.txt
+   pip install -r requirements.txt
    ```
 
 1. To test your installation, you can try to build and run the example below:

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,9 +18,5 @@ reuse
 torch
 cmake>=3.29, <4.0
 
-# MLIR-extras (Python bindings/helpers for MLIR)
-# For installing this, the following environment variables must be set:
-# MLIR_PYTHON_EXTRAS_SET_VERSION="0.0.8.3"
-# HOST_MLIR_PYTHON_PACKAGE_PREFIX="aie"
-git+https://github.com/erwei-xilinx/mlir-python-extras@46a55a3bc9138e29a9b90c5d2caa4bc3659bae35
+git+https://github.com/erwei-xilinx/mlir-python-extras@813dce4ec933c4b6517de4137dcba13d7304dcdf
 -f https://github.com/llvm/eudsl/releases/expanded_assets/latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,5 @@ cmake>=3.29, <4.0
 # For installing this, the following environment variables must be set:
 # MLIR_PYTHON_EXTRAS_SET_VERSION="0.0.8.3"
 # HOST_MLIR_PYTHON_PACKAGE_PREFIX="aie"
-git+https://github.com/erwei-xilinx/mlir-python-extras@a801853ac0eef50a0f2779cfbbd7dabc931806ee
+git+https://github.com/erwei-xilinx/mlir-python-extras@46a55a3bc9138e29a9b90c5d2caa4bc3659bae35
 -f https://github.com/llvm/eudsl/releases/expanded_assets/latest


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

Simplified install thanks to [erwei-xilinx/mlir-python-extras PR #1](https://github.com/erwei-xilinx/mlir-python-extras/pull/1).

## PR Merge Checklist

1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
