### PR TITLE
Fix Task Group Mixing

### DIFF
--- a/example/axpy/axpy.py
+++ b/example/axpy/axpy.py
@@ -87,29 +87,34 @@ def my_axpy(
     rt = Runtime()
     with rt.sequence(tensor_ty, tensor_ty, tensor_ty) as (A, B, C):
         rt.start(*my_workers)
+
+        # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+        tg = rt.task_group()
+
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             rt.fill(
                 of_in1s[i].prod(),
                 A,
                 taps[i],
+                task_group=tg,
             )
             rt.fill(
                 of_in2s[i].prod(),
                 B,
                 taps[i],
+                task_group=tg,
             )
         # Drain the output objectFIFOs with data
-        tg_out = rt.task_group()
         for i in range(num_columns):
             rt.drain(
                 of_outs[i].cons(),
                 C,
                 taps[i],
                 wait=True,  # wait for the transfer to complete and data to be available
-                task_group=tg_out,
+                task_group=tg,
             )
-        rt.finish_task_group(tg_out)
+        rt.finish_task_group(tg)
 
     # Place program components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())

--- a/example/dequant/dequant.py
+++ b/example/dequant/dequant.py
@@ -122,6 +122,10 @@ def my_dequant_kernel(
         if enable_trace:
             rt.enable_trace(trace_size)
         rt.start(*my_workers)
+
+        # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+        tg = rt.task_group()
+
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
@@ -129,9 +133,9 @@ def my_dequant_kernel(
                     of_in1s[i * num_channels + j].prod(),
                     A,
                     taps_in[i * num_channels + j],
+                    task_group=tg,
                 )
         # Drain the output objectFIFOs with data
-        tg_out = rt.task_group()
         for i in range(num_columns):
             for j in range(num_channels):
                 rt.drain(
@@ -139,9 +143,9 @@ def my_dequant_kernel(
                     C,
                     taps_out[i * num_channels + j],
                     wait=True,  # wait for the transfer to complete and data to be available
-                    task_group=tg_out,
+                    task_group=tg,
                 )
-        rt.finish_task_group(tg_out)
+        rt.finish_task_group(tg)
 
     # Place program components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())

--- a/example/elementwise_add/eltwise_add.py
+++ b/example/elementwise_add/eltwise_add.py
@@ -84,29 +84,34 @@ def my_eltwise_add(dev, num_elements, num_columns, num_channels, tile_size, trac
     rt = Runtime()
     with rt.sequence(tensor_ty, tensor_ty, tensor_ty) as (A, B, C):
         rt.start(*my_workers)
+
+        # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+        tg = rt.task_group()
+
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             rt.fill(
                 of_in1s[i].prod(),
                 A,
                 taps[i],
+                task_group=tg,
             )
             rt.fill(
                 of_in2s[i].prod(),
                 B,
                 taps[i],
+                task_group=tg,
             )
         # Drain the output objectFIFOs with data
-        tg_out = rt.task_group()
         for i in range(num_columns):
             rt.drain(
                 of_outs[i].cons(),
                 C,
                 taps[i],
                 wait=True,  # wait for the transfer to complete and data to be available
-                task_group=tg_out,
+                task_group=tg,
             )
-        rt.finish_task_group(tg_out)
+        rt.finish_task_group(tg)
 
     # Place program components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())

--- a/example/elementwise_mul/eltwise_mul.py
+++ b/example/elementwise_mul/eltwise_mul.py
@@ -83,29 +83,34 @@ def my_eltwise_mul(dev, num_elements, num_columns, num_channels, tile_size, trac
     rt = Runtime()
     with rt.sequence(tensor_ty, tensor_ty, tensor_ty) as (A, B, C):
         rt.start(*my_workers)
+
+        # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+        tg = rt.task_group()
+
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             rt.fill(
                 of_in1s[i].prod(),
                 A,
                 taps[i],
+                task_group=tg,
             )
             rt.fill(
                 of_in2s[i].prod(),
                 B,
                 taps[i],
+                task_group=tg,
             )
         # Drain the output objectFIFOs with data
-        tg_out = rt.task_group()
         for i in range(num_columns):
             rt.drain(
                 of_outs[i].cons(),
                 C,
                 taps[i],
                 wait=True,  # wait for the transfer to complete and data to be available
-                task_group=tg_out,
+                task_group=tg,
             )
-        rt.finish_task_group(tg_out)
+        rt.finish_task_group(tg)
 
     # Place program components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())

--- a/example/gelu/gelu.py
+++ b/example/gelu/gelu.py
@@ -92,6 +92,10 @@ def my_gelu(dev, size, num_columns, num_channels, tile_size, trace_size):
     rt = Runtime()
     with rt.sequence(transfer_type, transfer_type) as (a_in, b_out):
         rt.start(*my_workers)
+
+        # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+        tg = rt.task_group()
+
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
@@ -99,9 +103,9 @@ def my_gelu(dev, size, num_columns, num_channels, tile_size, trace_size):
                     of_ins[i * num_channels + j].prod(),
                     a_in,
                     taps[i * num_channels + j],
+                    task_group=tg,
                 )
         # Drain the output objectFIFOs with data
-        tg_out = rt.task_group()  # Initialize a group for parallel drain tasks
         for i in range(num_columns):
             for j in range(num_channels):
                 rt.drain(
@@ -109,9 +113,9 @@ def my_gelu(dev, size, num_columns, num_channels, tile_size, trace_size):
                     b_out,
                     taps[i * num_channels + j],
                     wait=True,  # wait for the transfer to complete and data to be available
-                    task_group=tg_out,
+                    task_group=tg,
                 )
-        rt.finish_task_group(tg_out)
+        rt.finish_task_group(tg)
 
     # Place components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())

--- a/example/layer_norm/layer_norm.py
+++ b/example/layer_norm/layer_norm.py
@@ -93,6 +93,10 @@ def my_layer_norm(dev, num_elements, num_columns, num_channels, trace_size, tile
     rt = Runtime()
     with rt.sequence(tensor_ty, tensor_ty) as (A, C):
         rt.start(*my_workers)
+
+        # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+        tg = rt.task_group()
+
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
@@ -100,9 +104,9 @@ def my_layer_norm(dev, num_elements, num_columns, num_channels, trace_size, tile
                     of_in1s[i * num_channels + j].prod(),
                     A,
                     taps[i * num_channels + j],
+                    task_group=tg,
                 )
         # Drain the output objectFIFOs with data
-        tg_out = rt.task_group()
         for i in range(num_columns):
             for j in range(num_channels):
                 rt.drain(
@@ -110,9 +114,9 @@ def my_layer_norm(dev, num_elements, num_columns, num_channels, trace_size, tile
                     C,
                     taps[i * num_channels + j],
                     wait=True,  # wait for the transfer to complete and data to be available
-                    task_group=tg_out,
+                    task_group=tg,
                 )
-        rt.finish_task_group(tg_out)
+        rt.finish_task_group(tg)
 
     # Place program components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())

--- a/example/leaky_relu/leaky_relu.py
+++ b/example/leaky_relu/leaky_relu.py
@@ -91,6 +91,10 @@ def my_leaky_relu(dev, size, num_columns, num_channels, tile_size, trace_size, a
     rt = Runtime()
     with rt.sequence(transfer_type, transfer_type) as (a_in, b_out):
         rt.start(*my_workers)
+
+        # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+        tg = rt.task_group()
+
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
@@ -98,9 +102,9 @@ def my_leaky_relu(dev, size, num_columns, num_channels, tile_size, trace_size, a
                     of_ins[i * num_channels + j].prod(),
                     a_in,
                     taps[i * num_channels + j],
+                    task_group=tg,
                 )
         # Drain the output objectFIFOs with data
-        tg_out = rt.task_group()  # Initialize a group for parallel drain tasks
         for i in range(num_columns):
             for j in range(num_channels):
                 rt.drain(
@@ -108,9 +112,9 @@ def my_leaky_relu(dev, size, num_columns, num_channels, tile_size, trace_size, a
                     b_out,
                     taps[i * num_channels + j],
                     wait=True,  # wait for the transfer to complete and data to be available
-                    task_group=tg_out,
+                    task_group=tg,
                 )
-        rt.finish_task_group(tg_out)
+        rt.finish_task_group(tg)
 
     # Place components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())

--- a/example/mem_copy/mem_copy.py
+++ b/example/mem_copy/mem_copy.py
@@ -92,6 +92,10 @@ def my_mem_copy(dev, size, num_columns, num_channels, tile_size, trace_size):
     rt = Runtime()
     with rt.sequence(transfer_type, transfer_type) as (a_in, b_out):
         rt.start(*my_workers)
+
+        # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+        tg = rt.task_group()
+
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
@@ -99,9 +103,9 @@ def my_mem_copy(dev, size, num_columns, num_channels, tile_size, trace_size):
                     of_ins[i * num_channels + j].prod(),
                     a_in,
                     taps[i * num_channels + j],
+                    task_group=tg,
                 )
         # Drain the output objectFIFOs with data
-        tg_out = rt.task_group()  # Initialize a group for parallel drain tasks
         for i in range(num_columns):
             for j in range(num_channels):
                 rt.drain(
@@ -109,9 +113,9 @@ def my_mem_copy(dev, size, num_columns, num_channels, tile_size, trace_size):
                     b_out,
                     taps[i * num_channels + j],
                     wait=True,  # wait for the transfer to complete and data to be available
-                    task_group=tg_out,
+                    task_group=tg,
                 )
-        rt.finish_task_group(tg_out)
+        rt.finish_task_group(tg)
 
     # Place components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())

--- a/example/mha/mha.py
+++ b/example/mha/mha.py
@@ -753,6 +753,9 @@ def batched_matmul_single_core(
 
             for q_block_idx in range(num_q_block_per_pipeline):
 
+                # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+                tg = rt.task_group()
+
                 if number_of_pipelines > 6:
                     rt.fill(
                         inQ.prod(),
@@ -761,6 +764,7 @@ def batched_matmul_single_core(
                             2 * head_idx * num_q_block_per_pipeline + q_block_idx * 2
                         ],
                         placement=Tile(col=4, row=0),
+                        task_group=tg,
                     )
                     rt.fill(
                         inQ2.prod(),
@@ -771,6 +775,7 @@ def batched_matmul_single_core(
                             + 1
                         ],
                         placement=Tile(col=4, row=0),
+                        task_group=tg,
                     )
                 else:
                     rt.fill(
@@ -778,14 +783,15 @@ def batched_matmul_single_core(
                         Q,
                         tap=Q_tiles[head_idx * num_q_block_per_pipeline + q_block_idx],
                         placement=Tile(col=4, row=0),
+                        task_group=tg,
                     )
 
                 # Thow on bd containing the full K and V in the object fifo, then does it transfer cunks of inKV size at the time?
                 rt.fill(
-                    inK.prod(), K, tap=K_tiles[head_idx], placement=Tile(col=5, row=0)
+                    inK.prod(), K, tap=K_tiles[head_idx], placement=Tile(col=5, row=0), task_group=tg,
                 )
                 rt.fill(
-                    inV.prod(), V, tap=V_tiles[head_idx], placement=Tile(col=6, row=0)
+                    inV.prod(), V, tap=V_tiles[head_idx], placement=Tile(col=6, row=0), task_group=tg,
                 )
 
                 if number_of_pipelines > 6:
@@ -797,6 +803,7 @@ def batched_matmul_single_core(
                         ],
                         wait=True,
                         placement=Tile(col=7, row=0),
+                        task_group=tg,
                     )
                     rt.drain(
                         memO2.cons(),
@@ -808,6 +815,7 @@ def batched_matmul_single_core(
                         ],
                         wait=True,
                         placement=Tile(col=7, row=0),
+                        task_group=tg,
                     )
                 else:
                     rt.drain(
@@ -816,7 +824,10 @@ def batched_matmul_single_core(
                         tap=O_tiles[head_idx * num_q_block_per_pipeline + q_block_idx],
                         wait=True,
                         placement=Tile(col=7, row=0),
+                        task_group=tg,
                     )
+
+                rt.finish_task_group(tg)
 
     # Create the program from the device type and runtime
     if dev == "npu":

--- a/example/mha/mha.py
+++ b/example/mha/mha.py
@@ -788,10 +788,18 @@ def batched_matmul_single_core(
 
                 # Thow on bd containing the full K and V in the object fifo, then does it transfer cunks of inKV size at the time?
                 rt.fill(
-                    inK.prod(), K, tap=K_tiles[head_idx], placement=Tile(col=5, row=0), task_group=tg,
+                    inK.prod(),
+                    K,
+                    tap=K_tiles[head_idx],
+                    placement=Tile(col=5, row=0),
+                    task_group=tg,
                 )
                 rt.fill(
-                    inV.prod(), V, tap=V_tiles[head_idx], placement=Tile(col=6, row=0), task_group=tg,
+                    inV.prod(),
+                    V,
+                    tap=V_tiles[head_idx],
+                    placement=Tile(col=6, row=0),
+                    task_group=tg,
                 )
 
                 if number_of_pipelines > 6:

--- a/example/relu/relu.py
+++ b/example/relu/relu.py
@@ -90,6 +90,10 @@ def my_relu(dev, size, num_columns, num_channels, tile_size, trace_size):
     rt = Runtime()
     with rt.sequence(transfer_type, transfer_type) as (a_in, b_out):
         rt.start(*my_workers)
+
+        # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+        tg = rt.task_group()
+
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
@@ -97,9 +101,9 @@ def my_relu(dev, size, num_columns, num_channels, tile_size, trace_size):
                     of_ins[i * num_channels + j].prod(),
                     a_in,
                     taps[i * num_channels + j],
+                    task_group=tg,
                 )
         # Drain the output objectFIFOs with data
-        tg_out = rt.task_group()  # Initialize a group for parallel drain tasks
         for i in range(num_columns):
             for j in range(num_channels):
                 rt.drain(
@@ -107,9 +111,9 @@ def my_relu(dev, size, num_columns, num_channels, tile_size, trace_size):
                     b_out,
                     taps[i * num_channels + j],
                     wait=True,  # wait for the transfer to complete and data to be available
-                    task_group=tg_out,
+                    task_group=tg,
                 )
-        rt.finish_task_group(tg_out)
+        rt.finish_task_group(tg)
 
     # Place components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())

--- a/example/rms_norm/rms_norm.py
+++ b/example/rms_norm/rms_norm.py
@@ -93,6 +93,10 @@ def my_rms_norm(dev, num_elements, num_columns, num_channels, trace_size, tile_s
     rt = Runtime()
     with rt.sequence(tensor_ty, tensor_ty) as (A, C):
         rt.start(*my_workers)
+
+        # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+        tg = rt.task_group()
+
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
@@ -100,9 +104,9 @@ def my_rms_norm(dev, num_elements, num_columns, num_channels, trace_size, tile_s
                     of_in1s[i * num_channels + j].prod(),
                     A,
                     taps[i * num_channels + j],
+                    task_group=tg,
                 )
         # Drain the output objectFIFOs with data
-        tg_out = rt.task_group()
         for i in range(num_columns):
             for j in range(num_channels):
                 rt.drain(
@@ -110,9 +114,9 @@ def my_rms_norm(dev, num_elements, num_columns, num_channels, trace_size, tile_s
                     C,
                     taps[i * num_channels + j],
                     wait=True,  # wait for the transfer to complete and data to be available
-                    task_group=tg_out,
+                    task_group=tg,
                 )
-        rt.finish_task_group(tg_out)
+        rt.finish_task_group(tg)
 
     # Place program components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())

--- a/example/rms_norm/weighted_rms_norm.py
+++ b/example/rms_norm/weighted_rms_norm.py
@@ -96,28 +96,33 @@ def my_weighted_rms_norm(
     rt = Runtime()
     with rt.sequence(tensor_ty, weights_ty, tensor_ty) as (A, B, C):
         rt.start(*my_workers)
+
+        # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+        tg = rt.task_group()
+
         # Fill the input objectFIFOs with data
         for i in range(total_cores):
             rt.fill(
                 of_in1s[i].prod(),
                 A,
                 taps[i],
+                task_group=tg,
             )
         rt.fill(
             of_in2s.prod(),
             B,
+            task_group=tg,
         )
         # Drain the output objectFIFOs with data
-        tg_out = rt.task_group()
         for i in range(total_cores):
             rt.drain(
                 of_outs[i].cons(),
                 C,
                 taps[i],
                 wait=True,
-                task_group=tg_out,
+                task_group=tg,
             )
-        rt.finish_task_group(tg_out)
+        rt.finish_task_group(tg)
 
     # Place program components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())

--- a/example/rope/rope.py
+++ b/example/rope/rope.py
@@ -94,29 +94,34 @@ def rope(
     rt = Runtime()
     with rt.sequence(tensor_ty, tensor_ty, tensor_ty) as (A, B, C):
         rt.start(*my_workers)
+
+        # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+        tg = rt.task_group()
+
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             rt.fill(
                 of_in[i].prod(),
                 A,
                 taps[i],
+                task_group=tg,
             )
             rt.fill(
                 of_lut[i].prod(),
                 B,
                 taps[i],
+                task_group=tg,
             )
         # Drain the output objectFIFOs with data
-        tg_out = rt.task_group()
         for i in range(num_columns):
             rt.drain(
                 of_out[i].cons(),
                 C,
                 taps[i],
                 wait=True,  # wait for the transfer to complete and data to be available
-                task_group=tg_out,
+                task_group=tg,
             )
-        rt.finish_task_group(tg_out)
+        rt.finish_task_group(tg)
 
     # Place program components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())

--- a/example/silu/silu.py
+++ b/example/silu/silu.py
@@ -95,6 +95,10 @@ def my_silu(dev, size, num_columns, num_channels, tile_size, trace_size):
         b_out,
     ):
         rt.start(*my_workers)
+
+        # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+        tg = rt.task_group()
+
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
@@ -102,9 +106,9 @@ def my_silu(dev, size, num_columns, num_channels, tile_size, trace_size):
                     of_ins[i * num_channels + j].prod(),
                     a_in,
                     taps[i * num_channels + j],
+                    task_group=tg,
                 )
         # Drain the output objectFIFOs with data
-        tg_out = rt.task_group()  # Initialize a group for parallel drain tasks
         for i in range(num_columns):
             for j in range(num_channels):
                 rt.drain(
@@ -112,9 +116,9 @@ def my_silu(dev, size, num_columns, num_channels, tile_size, trace_size):
                     b_out,
                     taps[i * num_channels + j],
                     wait=True,  # wait for the transfer to complete and data to be available
-                    task_group=tg_out,
+                    task_group=tg,
                 )
-        rt.finish_task_group(tg_out)
+        rt.finish_task_group(tg)
 
     # Place components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())

--- a/example/softmax/softmax.py
+++ b/example/softmax/softmax.py
@@ -90,6 +90,10 @@ def softmax(dev, num_elements, num_columns, num_channels, trace_size, tile_size)
     dummy_ty = tensor_ty
     with rt.sequence(tensor_ty, dummy_ty, tensor_ty) as (A, dummy, C):
         rt.start(*my_workers)
+
+        # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+        tg = rt.task_group()
+
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
@@ -97,9 +101,9 @@ def softmax(dev, num_elements, num_columns, num_channels, trace_size, tile_size)
                     of_in1s[i * num_channels + j].prod(),
                     A,
                     taps[i * num_channels + j],
+                    task_group=tg,
                 )
         # Drain the output objectFIFOs with data
-        tg_out = rt.task_group()
         for i in range(num_columns):
             for j in range(num_channels):
                 rt.drain(
@@ -107,9 +111,9 @@ def softmax(dev, num_elements, num_columns, num_channels, trace_size, tile_size)
                     C,
                     taps[i * num_channels + j],
                     wait=True,  # wait for the transfer to complete and data to be available
-                    task_group=tg_out,
+                    task_group=tg,
                 )
-        rt.finish_task_group(tg_out)
+        rt.finish_task_group(tg)
 
     # Place program components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())

--- a/example/transpose/transpose.py
+++ b/example/transpose/transpose.py
@@ -134,6 +134,10 @@ def shuffle_transpose(dev, M, N, num_columns, num_channels, trace_size, m, n, s)
     rt = Runtime()
     with rt.sequence(tensor_ty, tensor_ty) as (A, C):
         rt.start(*my_workers)
+
+        # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
+        tg = rt.task_group()
+
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
@@ -141,9 +145,9 @@ def shuffle_transpose(dev, M, N, num_columns, num_channels, trace_size, m, n, s)
                     of_in1s_L3L2[i * num_channels + j].prod(),
                     A,
                     taps_in_L3L2[i * num_channels + j],
+                    task_group=tg,
                 )
         # Drain the output objectFIFOs with data
-        tg_out = rt.task_group()
         for i in range(num_columns):
             for j in range(num_channels):
                 rt.drain(
@@ -151,9 +155,9 @@ def shuffle_transpose(dev, M, N, num_columns, num_channels, trace_size, m, n, s)
                     C,
                     taps_out_L1L3[i * num_channels + j],
                     wait=True,  # wait for the transfer to complete and data to be available
-                    task_group=tg_out,
+                    task_group=tg,
                 )
-        rt.finish_task_group(tg_out)
+        rt.finish_task_group(tg)
 
     # Place program components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

Address https://github.com/amd/IRON/issues/15. 

## Added
- Using task groups in the inner-most loop of MHA runtime. Without it, a long list of BD errors shows up. Checking with previous CI results, this change doesn't seem to negatively affect the performance of MHA.

## Changed
- Use same task groups for fill operations as the drain operations in operators such as AXPY, etc. 

## PR Merge Checklist

1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
