### PR TITLE
Fix AIE device detection after upstream change

### DIFF
--- a/applications/llama_3.2_1b/src/aie_device_manager.py
+++ b/applications/llama_3.2_1b/src/aie_device_manager.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 from typing import Dict, Optional, Any
 import pyxrt
-from aie.iron.config import detect_npu_device
+from aie.iron.hostruntime.config import detect_npu_device
 from aie.iron.device import NPU1, NPU2
 
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

Xilinx/mlir-aie PR #2692 moved `aie.iron.config` to `aie.iron.hostruntime.config`.

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR has been reviewed and approved.
3. [x] All checks are passing.
