### PR TITLE
Update CI to enable PR comments on fork commits

### DIFF
--- a/.github/actions/commit_results/action.yaml
+++ b/.github/actions/commit_results/action.yaml
@@ -28,6 +28,7 @@ runs:
       id: merge_results
       env:
         HOME: /workspace
+        PR_NUMBER: ${{ github.event.number }}
       shell: bash
       run: |
         export DATE=$(printf '%(%Y_%m_%d_%H_%M_%S)T')
@@ -48,62 +49,12 @@ runs:
         ./ci/scripts/merge_all.py --all ${RESULTS_DIR}/all.csv --latest ${RESULTS_DIR}/latest.csv
         ./ci/scripts/pretty_trends.py ${RESULTS_DIR}/all.csv -o ${RESULTS_DIR}/trends.md
 
+        echo ${PR_NUMBER} > ${RESULTS_DIR}/pr_number
+        echo ${COMMIT_SHA} > ${RESULTS_DIR}/commit_sha
+        echo ${DATE} > ${RESULTS_DIR}/date
         echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
         echo "date=${DATE}" >> $GITHUB_OUTPUT
         echo "results_dir=${RESULTS_DIR}" >> $GITHUB_OUTPUT
-
-    - name: Comment results on PR
-      if: ${{ startsWith(github.event_name, 'pull_request') }}
-      continue-on-error: true  # This step will fail for PRs from forks because of permission issues; ignore
-      uses: actions/github-script@v7
-      with:
-        github-token: ${{ github.token }}
-        script: |
-          const fs = require('fs');
-          const commitSha = '${{ steps.merge_results.outputs.commit_sha }}';
-          const date = '${{ steps.merge_results.outputs.date }}';
-          const server = '${{ github.server_url }}';
-          const repo = '${{ github.repository }}';
-          
-          let prettyContent = '';
-          try {
-            prettyContent = fs.readFileSync(`${{ steps.merge_results.outputs.results_dir }}/readme.md`, 'utf8');
-          } catch (error) {
-            prettyContent = 'Pretty output not available.';
-          }
-          
-          // Read the trends.md content
-          let trendsContent = '';
-          try {
-            trendsContent = fs.readFileSync(`${{ steps.merge_results.outputs.results_dir }}/trends.md`, 'utf8');
-          } catch (error) {
-            trendsContent = 'Trends not available.';
-          }
-          
-          const body = `<details>
-          <summary>📊 Test Results for ${process.env.GITHUB_WORKFLOW}</summary>
-
-          [${commitSha}](${server}/${repo}/commit/${commitSha}) (${date})
-          
-          ${prettyContent}
-          
-          </details>
-          
-          <details>
-          <summary>📈 Trends (vs main branch) for ${process.env.GITHUB_WORKFLOW}</summary>
-
-          [${commitSha}](${server}/${repo}/commit/${commitSha}) (${date})
-
-          ${trendsContent}
-          
-          </details>`;
-          
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: body
-          });
 
     - name: Push new test results to branch
       if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/devel') }}

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Adapted from https://stackoverflow.com/a/71683208
+
+# Commenting on a PR is a separate workflow from the others so that PRs from 
+# forks can receive comments as well. Since this workflow is not triggered by
+# a pull request event, but instead by the completion of another workflow, we
+# have write permissions to the repository and can therefore comment on the PR.
+
+name: Comment on PR with Test Results
+
+on:
+  workflow_run:
+    workflows: [Small Benchmark/Test Suite, Test Example Applications]
+    types:
+      - completed
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/github-script@v5
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/artifact.zip`, Buffer.from(download.data));
+
+      - name: Unzip artifact
+        shell: bash
+        run: unzip artifact.zip
+
+      - name: Comment results on PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('fs');
+            const issue_number = Number(fs.readFileSync('./pr_number'));
+            const commitSha = fs.readFileSync('./commit_sha');
+            const date = fs.readFileSync('./date');
+            const server = '${{ github.server_url }}';
+            const repo = '${{ github.repository }}';
+            
+            let prettyContent = '';
+            try {
+              prettyContent = fs.readFileSync(`./readme.md`, 'utf8');
+            } catch (error) {
+              prettyContent = 'Pretty output not available.';
+            }
+            
+            // Read the trends.md content
+            let trendsContent = '';
+            try {
+              trendsContent = fs.readFileSync(`./trends.md`, 'utf8');
+            } catch (error) {
+              trendsContent = 'Trends not available.';
+            }
+            
+            const body = `<details>
+                  <summary>📊 Test Results for ${context.payload.workflow_run.name}</summary>
+
+            [${commitSha}](${server}/${repo}/commit/${commitSha}) (${date})
+            
+            ${prettyContent}
+            
+            </details>
+            
+            <details>
+            <summary>📈 Trends (vs main branch) for  ${context.payload.workflow_run.name}</summary>
+
+            [${commitSha}](${server}/${repo}/commit/${commitSha}) (${date})
+
+            ${trendsContent}
+            
+            </details>`;
+            
+            github.rest.issues.createComment({
+              issue_number: issue_number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Changed
- Changed the CI action that comments on PRs with test/benchmark results. Using a separate workflow should enable necessary permissions to do this even for PRs from forks.

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
