### PR TITLE
Fix CI PR comments permission issue and handle cancellations gracefully

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -23,44 +23,28 @@ jobs:
     steps:
       - name: Download artifact
         id: download
-        uses: actions/github-script@v5
+        continue-on-error: true
+        uses: actions/download-artifact@v5
         with:
-          script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            let matchArtifact = allArtifacts.data.artifacts[0];
-            if (!matchArtifact) {
-              console.log('No artifacts found. Skipping remaining steps.');
-              core.setOutput('has-artifact', 'false');
-              return;
-            }
-            core.setOutput('has-artifact', 'true');
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            let fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/artifact.zip`, Buffer.from(download.data));
-
-      - name: Unzip artifact
-        if: steps.download.outputs.has-artifact == 'true'
-        shell: bash
-        run: unzip artifact.zip
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          merge-multiple: true
 
       - name: Comment results on PR
-        if: steps.download.outputs.has-artifact == 'true'
+        if: steps.download.outcome == 'success'
         uses: actions/github-script@v7
         with:
           github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
-            const maybe_issue_number = fs.readFileSync('./pr_number', 'utf8').trim();
-            const issue_number = Number(maybe_issue_number);
+            
+            // Check if pr_number file exists
+            if (!fs.existsSync('./pr_number')) {
+              console.log('No pr_number file found. Skipping comment.');
+              return;
+            }
+            
+            const issue_number = Number(fs.readFileSync('./pr_number', 'utf8').trim());
             
             // Skip if not triggered by a PR (pr_number will be empty or invalid)
             if (!issue_number || isNaN(issue_number)) {

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -37,14 +37,17 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
+            const path = require('path');
+            const downloadPath = '${{ steps.download.outputs.download-path }}' || process.env.GITHUB_WORKSPACE;
             
             // Check if pr_number file exists
-            if (!fs.existsSync('./pr_number')) {
+            const prNumberPath = path.join(downloadPath, 'pr_number');
+            if (!fs.existsSync(prNumberPath)) {
               console.log('No pr_number file found. Skipping comment.');
               return;
             }
             
-            const issue_number = Number(fs.readFileSync('./pr_number', 'utf8').trim());
+            const issue_number = Number(fs.readFileSync(prNumberPath, 'utf8').trim());
             
             // Skip if not triggered by a PR (pr_number will be empty or invalid)
             if (!issue_number || isNaN(issue_number)) {
@@ -52,14 +55,14 @@ jobs:
               return;
             }
             
-            const commitSha = fs.readFileSync('./commit_sha', 'utf8').trim();
-            const date = fs.readFileSync('./date', 'utf8').trim();
+            const commitSha = fs.readFileSync(path.join(downloadPath, 'commit_sha'), 'utf8').trim();
+            const date = fs.readFileSync(path.join(downloadPath, 'date'), 'utf8').trim();
             const server = '${{ github.server_url }}';
             const repo = '${{ github.repository }}';
             
             let prettyContent = '';
             try {
-              prettyContent = fs.readFileSync(`./readme.md`, 'utf8');
+              prettyContent = fs.readFileSync(path.join(downloadPath, 'readme.md'), 'utf8');
             } catch (error) {
               prettyContent = 'Pretty output not available.';
             }
@@ -67,7 +70,7 @@ jobs:
             // Read the trends.md content
             let trendsContent = '';
             try {
-              trendsContent = fs.readFileSync(`./trends.md`, 'utf8');
+              trendsContent = fs.readFileSync(path.join(downloadPath, 'trends.md'), 'utf8');
             } catch (error) {
               trendsContent = 'Trends not available.';
             }

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -18,8 +18,11 @@ on:
 jobs:
   download:
     runs-on: ubuntu-latest
+    # Only run if the workflow completed (not cancelled)
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}
     steps:
       - name: Download artifact
+        id: download
         uses: actions/github-script@v5
         with:
           script: |
@@ -29,6 +32,12 @@ jobs:
                run_id: context.payload.workflow_run.id,
             });
             let matchArtifact = allArtifacts.data.artifacts[0];
+            if (!matchArtifact) {
+              console.log('No artifacts found. Skipping remaining steps.');
+              core.setOutput('has-artifact', 'false');
+              return;
+            }
+            core.setOutput('has-artifact', 'true');
             let download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
@@ -39,10 +48,12 @@ jobs:
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/artifact.zip`, Buffer.from(download.data));
 
       - name: Unzip artifact
+        if: steps.download.outputs.has-artifact == 'true'
         shell: bash
         run: unzip artifact.zip
 
       - name: Comment results on PR
+        if: steps.download.outputs.has-artifact == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -59,9 +59,17 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
-            const issue_number = Number(fs.readFileSync('./pr_number'));
-            const commitSha = fs.readFileSync('./commit_sha');
-            const date = fs.readFileSync('./date');
+            const maybe_issue_number = fs.readFileSync('./pr_number', 'utf8').trim();
+            const issue_number = Number(maybe_issue_number);
+            
+            // Skip if not triggered by a PR (pr_number will be empty or invalid)
+            if (!issue_number || isNaN(issue_number)) {
+              console.log('Not triggered by a PR. Skipping comment.');
+              return;
+            }
+            
+            const commitSha = fs.readFileSync('./commit_sha', 'utf8').trim();
+            const date = fs.readFileSync('./date', 'utf8').trim();
             const server = '${{ github.server_url }}';
             const repo = '${{ github.repository }}';
             


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Changed
- Replace the GitHub script implementation of "download artifact" with the dedicated "actions/download-artifact" action. The current implementation receives a 403 Forbidden error when trying to download the artifact; this new simpler implementation (which uses the GitHub token for authentication) hopefully fixes that. Unfortunately we will only know whether this was fixed once it is merged in `devel`.
- The workflow that adds comments to PRs with the test/benchmark results will fail when the workflow that triggered it is cancelled (because there are no artifacts). This change handles such cancellations gracefully.
- Also handle gracefully if the workflow that triggered this was not from a PR (e.g. nightly runs or pushes to main).

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR has been reviewed and approved.
3. [x] All checks are passing.
