### PR TITLE
Limit CI 'Trends' output to two most recent commits

### DIFF
--- a/.github/actions/commit_results/action.yaml
+++ b/.github/actions/commit_results/action.yaml
@@ -46,8 +46,11 @@ runs:
 
         RESULTS_DIR=$(realpath ../results/${{ inputs.dir }})
 
-        ./ci/scripts/merge_all.py --all ${RESULTS_DIR}/all.csv --latest ${RESULTS_DIR}/latest.csv
-        ./ci/scripts/pretty_trends.py ${RESULTS_DIR}/all.csv -o ${RESULTS_DIR}/trends.md
+        cp ${RESULTS_DIR}/all.csv ${RESULTS_DIR}/last_two.csv
+        ./ci/scripts/merge_all.py --all ${RESULTS_DIR}/all.csv --latest ${RESULTS_DIR}/latest.csv --limit 1000
+        ./ci/scripts/merge_all.py --all ${RESULTS_DIR}/last_two.csv --latest ${RESULTS_DIR}/latest.csv --limit 2
+        ./ci/scripts/pretty_trends.py ${RESULTS_DIR}/last_two.csv -o ${RESULTS_DIR}/trends.md
+        rm ${RESULTS_DIR}/last_two.csv
 
         echo ${PR_NUMBER} > ${RESULTS_DIR}/pr_number
         echo ${COMMIT_SHA} > ${RESULTS_DIR}/commit_sha


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

The existing benchmark results have already accumulated to a degree where the PR commit messages are getting longer than GitHub allows.

For PR comments, we're likely only interested in the last two commits anyways (the commit of the PR and the latest `devel` for comparsion).

Therefore, this change restricts the PR "trends" comment output to those latest two commits.

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR has been reviewed and approved.
3. [x] All checks are passing.
