### PR TITLE
Update gemm tiling dim (n) and move function to appropriate spot

### DIFF
--- a/example/gemm/CMakeLists.txt
+++ b/example/gemm/CMakeLists.txt
@@ -73,34 +73,6 @@ function(add_aie_gemm_design M K N m k n NUM_COLUMNS B_COL_MAJ C_COL_MAJ TRACE_S
                         "GFLOP/s" [=[Throughput:\s*(?P<metric>[\d\.e\+-]+) GFLOP/s]=])
 endfunction()
 
-set(M_LIST "2048")
-set(K_LIST "2048")
-set(N_LIST "2048")
-
-# Fix the AIE core tile dimensions
-# TODO: Do we need to sweep through a list of them instead?
-set(m "64")
-set(k "64")
-set(n "32")
-
-set(AIE_BUILD_DIR ${CMAKE_BINARY_DIR}/aie)
-
-set(PRIO_ACCURACY True)
-set(EMULATE_BFLOAT16_MMUL_WITH_BFP16 False)
-
-# Common kernel defines setup
-set(MM_KERNEL_DEFINES_BASE "DIM_M=${m}" "DIM_K=${k}" "DIM_N=${n}" "ROUND_CONV_EVEN")
-if (EMULATE_BFLOAT16_MMUL_WITH_BFP16)
-    set(EMULATE_STR --emulate-bf16-mmul-with-bfp16)
-    list(APPEND MM_KERNEL_DEFINES_BASE "AIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16")
-endif()
-if (PRIO_ACCURACY)
-    set(PRIO_ACC_STR --prio-accuracy)
-    list(APPEND MM_KERNEL_DEFINES_BASE "bf16_f32_ONLY")
-else()
-    list(APPEND MM_KERNEL_DEFINES_BASE "bf16_bf16_ONLY")
-endif()
-
 function(add_gemm_archive m k n B_COL_MAJ C_COL_MAJ CONVERT_OBJ)
     # Set up kernel defines based on configuration
     set(MM_KERNEL_DEFINES ${MM_KERNEL_DEFINES_BASE})
@@ -129,6 +101,34 @@ function(add_gemm_archive m k n B_COL_MAJ C_COL_MAJ CONVERT_OBJ)
     # Export archive name to parent scope
     set(ARCHIVE_NAME ${ARCHIVE_NAME} PARENT_SCOPE)
 endfunction()
+
+set(M_LIST "2048")
+set(K_LIST "2048")
+set(N_LIST "2048")
+
+# Fix the AIE core tile dimensions
+# TODO: Do we need to sweep through a list of them instead?
+set(m "64")
+set(k "64")
+set(n "64")
+
+set(AIE_BUILD_DIR ${CMAKE_BINARY_DIR}/aie)
+
+set(PRIO_ACCURACY True)
+set(EMULATE_BFLOAT16_MMUL_WITH_BFP16 False)
+
+# Common kernel defines setup
+set(MM_KERNEL_DEFINES_BASE "DIM_M=${m}" "DIM_K=${k}" "DIM_N=${n}" "ROUND_CONV_EVEN")
+if (EMULATE_BFLOAT16_MMUL_WITH_BFP16)
+    set(EMULATE_STR --emulate-bf16-mmul-with-bfp16)
+    list(APPEND MM_KERNEL_DEFINES_BASE "AIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16")
+endif()
+if (PRIO_ACCURACY)
+    set(PRIO_ACC_STR --prio-accuracy)
+    list(APPEND MM_KERNEL_DEFINES_BASE "bf16_f32_ONLY")
+else()
+    list(APPEND MM_KERNEL_DEFINES_BASE "bf16_bf16_ONLY")
+endif()
 
 add_aie_kernel("convert_copy" SOURCES ${CMAKE_SOURCE_DIR}/aie_kernels/generic/convert_copy.cc OUTPUT_OBJECT CONVERT_OBJ)
 

--- a/example/gemm/gemm.py
+++ b/example/gemm/gemm.py
@@ -50,7 +50,7 @@ def main():
     argparser.add_argument("-N", type=int, default=512)
     argparser.add_argument("-m", type=int, default=64)
     argparser.add_argument("-k", type=int, default=64)
-    argparser.add_argument("-n", type=int, default=32)
+    argparser.add_argument("-n", type=int, default=64)
     argparser.add_argument("--n-aie-cols", type=int, choices=[1, 2, 4, 8], default=4)
     argparser.add_argument("--b-col-maj", type=int, choices=[0, 1], default=0)
     argparser.add_argument("--c-col-maj", type=int, choices=[0, 1], default=0)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

For some reason tiling dim `n` for GEMM in CMake was `32` instead of `64`--updated it to be `64`.

## Changed
- Gemm tiling dimension `n` increased to `64`
- The `add_gemm_archive` function was in an incorrect spot, so moved it with the other functions

## PR Merge Checklist

1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
