### PR TITLE
Fix null version error in update-mlir-aie action

### DIFF
--- a/.github/workflows/update-mlir-aie.yml
+++ b/.github/workflows/update-mlir-aie.yml
@@ -36,8 +36,14 @@ jobs:
 
       - name: Get latest mlir-aie release
         id: latest_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          latest_tag_with_v=$(curl -s "https://api.github.com/repos/Xilinx/mlir-aie/releases/latest" | jq -r '.tag_name')
+          latest_tag_with_v=$(gh api repos/Xilinx/mlir-aie/releases/latest --jq .tag_name)
+          if [ -z "$latest_tag_with_v" ] || [ "$latest_tag_with_v" = "null" ]; then
+            echo "Failed to fetch latest release tag."
+            exit 1
+          fi
           latest_tag="${latest_tag_with_v#v}"
           echo "Latest tag: $latest_tag"
           echo "tag_with_v=$latest_tag_with_v" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

Ensure that bumps to "null" versions do not occur any more, e.g., avoid nightly PRs like: https://github.com/amd/IRON/pull/59

## Added
-

## Changed
- Use gh instead of curl for more programmatic fetching of mlir-aie latest version.
- Test for null; exit if null.

## Removed
-

## PR Merge Checklist

1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
