### PR TITLE
GQA without repeat interleave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ id_ed25519.pub
 *.safetensors
 *.model
 .cline_storage
+*.egg-info

--- a/conftest.py
+++ b/conftest.py
@@ -14,9 +14,10 @@ from iron.common import AIEContext
 
 
 @pytest.fixture
-def aie_context():
+def aie_context(request):
     """Create a fresh AIEContext for each test"""
-    return AIEContext()
+    verbose_mlir = request.config.option.verbose > 0
+    return AIEContext(mlir_verbose=verbose_mlir)
 
 
 def pytest_addoption(parser):

--- a/iron/common/aie_context.py
+++ b/iron/common/aie_context.py
@@ -14,7 +14,7 @@ import aie.utils.config
 class AIEContext:
     """Context for managing AIE operator compilation and runtime state"""
 
-    def __init__(self, use_runlist=True):
+    def __init__(self, use_runlist=True, mlir_verbose=None):
         self.operators = []
         self.static_data_pool = {}
         self.device_manager = AIEDeviceManager()
@@ -24,6 +24,7 @@ class AIEContext:
         self.peano_dir = Path(aie.utils.config.peano_install_dir())
         # Disable the XRT runlist sacrifices performance by executing kernels individually as separate xclbin invocations for easier debugging (can tell which part of runlist execution failed)
         self.use_runlist = use_runlist
+        self.mlir_verbose = bool(mlir_verbose)
         self._runtime_prepared = False
 
     def register_operator(self, operator):

--- a/iron/operators/gemv/design.py
+++ b/iron/operators/gemv/design.py
@@ -32,9 +32,15 @@ Calls into the mv.cc kernel code. That kernel computes `m_input` output rows per
 """
 
 
-def my_matvec(dev, cols, M, K, m_input, m_output=None):
+def my_matvec(dev, cols, M, K, m_input, m_output=None, verbose=False):
     if m_output is None:
         m_output = m_input
+
+    if verbose:
+        print(f"Device: {dev}")
+        print(f"Matrix dimensions: M={M}, K={K}")
+        print(f"Tiling: m_input={m_input}, m_output={m_output}")
+        print(f"Columns: {cols}")
 
     # The reason for the following requirement is because we first acquire output rows from the C FIFO, then fill those acquiring rows of the A input.
     assert (

--- a/iron/operators/gemv/op.py
+++ b/iron/operators/gemv/op.py
@@ -62,6 +62,7 @@ class AIEGEMV(AIEOperatorBase):
         # The underlying MLIR design is a matrix-vector multiplication. We support vector-matrix multiplication by transposing the matrix beforehand (AB = C <=> B^T A^T = C^T).
         operator_dir = Path(__file__).parent
         file_name_base = f"{prefix}{self.M}x{self.K}_{self.tile_size_input}tsi_{self.tile_size_output}tso_{self.num_aie_columns}col"
+        mlir_verbose = getattr(self.context, "mlir_verbose", False)
 
         mlir_artifact = PythonGeneratedMLIRArtifact.new(
             f"{file_name_base}.mlir",
@@ -74,6 +75,7 @@ class AIEGEMV(AIEOperatorBase):
                 self.K,
                 self.tile_size_input,
                 self.tile_size_output,
+                mlir_verbose,
             ],
         )
 

--- a/iron/operators/mha/design.py
+++ b/iron/operators/mha/design.py
@@ -712,9 +712,13 @@ def fused_mha(
         (heads * S_q_pad, d), (number_of_pipelines_join_distribute * B_q, d), (1, 1)
     )
 
-    K_tiles = TensorTiler2D.group_tiler((num_KV_heads * S_kv_pad, d), (S_kv_pad, d), (1, 1))
+    K_tiles = TensorTiler2D.group_tiler(
+        (num_KV_heads * S_kv_pad, d), (S_kv_pad, d), (1, 1)
+    )
 
-    V_tiles = TensorTiler2D.group_tiler((num_KV_heads * S_kv_pad, d), (S_kv_pad, d), (1, 1))
+    V_tiles = TensorTiler2D.group_tiler(
+        (num_KV_heads * S_kv_pad, d), (S_kv_pad, d), (1, 1)
+    )
 
     O_tiles = TensorTiler2D.group_tiler(
         (heads * S_q_pad, d), (number_of_pipelines_join_distribute * B_q, d), (1, 1)

--- a/iron/operators/mha/design.py
+++ b/iron/operators/mha/design.py
@@ -712,9 +712,9 @@ def fused_mha(
         (heads * S_q_pad, d), (number_of_pipelines_join_distribute * B_q, d), (1, 1)
     )
 
-    K_tiles = TensorTiler2D.group_tiler((heads * S_kv_pad, d), (S_kv_pad, d), (1, 1))
+    K_tiles = TensorTiler2D.group_tiler((num_KV_heads * S_kv_pad, d), (S_kv_pad, d), (1, 1))
 
-    V_tiles = TensorTiler2D.group_tiler((heads * S_kv_pad, d), (S_kv_pad, d), (1, 1))
+    V_tiles = TensorTiler2D.group_tiler((num_KV_heads * S_kv_pad, d), (S_kv_pad, d), (1, 1))
 
     O_tiles = TensorTiler2D.group_tiler(
         (heads * S_q_pad, d), (number_of_pipelines_join_distribute * B_q, d), (1, 1)
@@ -758,9 +758,9 @@ def fused_mha(
 
     if verbose:
         print(f"DMA Transfer Configuration: DRAM <-> Mem tile")
-        # print_tap_seq_info(Q_tiles, "Q")
-        # print_tap_seq_info(K_tiles, "K")
-        # print_tap_seq_info(V_tiles, "V")
+        print_tap_seq_info(Q_tiles, "Q")
+        print_tap_seq_info(K_tiles, "K")
+        print_tap_seq_info(V_tiles, "V")
         print_tap_seq_info(O_tiles, "O")
 
     # Runtime operations to move data to/from the AIE-array
@@ -787,6 +787,8 @@ def fused_mha(
             rt.start(matmul_pv_workers[i])
 
         for head_idx in range(heads):
+
+            kv_head_idx = head_idx // (heads // num_KV_heads)
 
             for q_block_idx in range(num_q_block_per_pipeline):
 
@@ -827,14 +829,14 @@ def fused_mha(
                 rt.fill(
                     inK.prod(),
                     K,
-                    tap=K_tiles[head_idx],
+                    tap=K_tiles[kv_head_idx],
                     placement=Tile(col=5, row=0),
                     task_group=tg,
                 )
                 rt.fill(
                     inV.prod(),
                     V,
-                    tap=V_tiles[head_idx],
+                    tap=V_tiles[kv_head_idx],
                     placement=Tile(col=6, row=0),
                     task_group=tg,
                 )

--- a/iron/operators/mha/design.py
+++ b/iron/operators/mha/design.py
@@ -758,10 +758,10 @@ def fused_mha(
 
     if verbose:
         print(f"DMA Transfer Configuration: DRAM <-> Mem tile")
-        print_tap_seq_info(Q_tiles, "Q")
+        # print_tap_seq_info(Q_tiles, "Q")
         print_tap_seq_info(K_tiles, "K")
         print_tap_seq_info(V_tiles, "V")
-        print_tap_seq_info(O_tiles, "O")
+        # print_tap_seq_info(O_tiles, "O")
 
     # Runtime operations to move data to/from the AIE-array
     rt = Runtime()

--- a/iron/operators/mha/op.py
+++ b/iron/operators/mha/op.py
@@ -53,6 +53,7 @@ class AIEMHA(AIEOperatorBase):
 
         kv_heads = self.num_KV_heads if self.num_KV_heads > 0 else self.num_heads
         file_name_base = f"mha_{self.num_heads}h_{kv_heads}kv_{self.seq_len}s_{self.d}d"
+        mlir_verbose = getattr(self.context, "mlir_verbose", False)
 
         # Define source files
         mm_source = str(self.context.base_dir / "aie_kernels" / "aie2p" / "mm.cc")
@@ -98,7 +99,7 @@ class AIEMHA(AIEOperatorBase):
                 "number_of_pipelines": self.num_of_pipelines,
                 "emulate_bf16_mmul_with_bfp16": True,
                 "trace_size": 0,
-                "verbose": False,
+                "verbose": mlir_verbose,
             },
         )
 

--- a/iron/operators/mha/op.py
+++ b/iron/operators/mha/op.py
@@ -103,7 +103,7 @@ class AIEMHA(AIEOperatorBase):
         )
 
         xclbin_artifact = XclbinArtifact.new(
-            f"mha.xclbin",
+            f"{file_name_base}.xclbin",
             depends=[
                 mlir_artifact,
                 KernelArchiveArtifact.new(
@@ -139,7 +139,7 @@ class AIEMHA(AIEOperatorBase):
         )
 
         insts_artifact = InstsBinArtifact.new(
-            f"mha.bin", depends=[mlir_artifact], extra_flags=["--dynamic-objFifos"]
+            f"{file_name_base}.bin", depends=[mlir_artifact], extra_flags=["--dynamic-objFifos"]
         )
 
         self.xclbin_artifact = xclbin_artifact

--- a/iron/operators/mha/op.py
+++ b/iron/operators/mha/op.py
@@ -139,7 +139,9 @@ class AIEMHA(AIEOperatorBase):
         )
 
         insts_artifact = InstsBinArtifact.new(
-            f"{file_name_base}.bin", depends=[mlir_artifact], extra_flags=["--dynamic-objFifos"]
+            f"{file_name_base}.bin",
+            depends=[mlir_artifact],
+            extra_flags=["--dynamic-objFifos"],
         )
 
         self.xclbin_artifact = xclbin_artifact

--- a/iron/operators/mha/reference.py
+++ b/iron/operators/mha/reference.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
+from torch.nn.attention import SDPBackend, sdpa_kernel
+
 import numpy as np
 from ml_dtypes import bfloat16
 
@@ -64,14 +66,16 @@ def generate_golden_reference(
 
     # MHA from PyTorch
     inv_scale = 1 / np.sqrt(K.shape[-1])
-    O = torch.nn.functional.scaled_dot_product_attention(
-        Q.to(torch.bfloat16),
-        K.to(torch.bfloat16),
-        V.to(torch.bfloat16),
-        dropout_p=0.0,
-        is_causal=True,
-        scale=inv_scale,
-    )
+
+    with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+        O = torch.nn.functional.scaled_dot_product_attention(
+            Q.to(torch.bfloat16).unsqueeze(0),
+            K.to(torch.bfloat16).unsqueeze(0),
+            V.to(torch.bfloat16).unsqueeze(0),
+            dropout_p=0.0,
+            is_causal=True,
+            scale=inv_scale,
+        ).squeeze(0)
 
     # Pad all tensors to multiple of 64
     Q = pad_to_multiple_of_64(Q, seq_dim=1, num_pipeline=num_pipeline)

--- a/iron/operators/mha/reference.py
+++ b/iron/operators/mha/reference.py
@@ -61,6 +61,9 @@ def generate_golden_reference(
     K = torch.rand(num_kv_heads, S_kv, d, dtype=torch.bfloat16) * val_range
     V = torch.rand(num_kv_heads, S_kv, d, dtype=torch.bfloat16) * val_range
 
+    K_original = K.clone()
+    V_original = V.clone()
+
     K = K.repeat_interleave(number_of_groups, dim=0)
     V = V.repeat_interleave(number_of_groups, dim=0)
 
@@ -79,13 +82,13 @@ def generate_golden_reference(
 
     # Pad all tensors to multiple of 64
     Q = pad_to_multiple_of_64(Q, seq_dim=1, num_pipeline=num_pipeline)
-    K = pad_to_multiple_of_64(K, seq_dim=1, num_pipeline=num_pipeline)
-    V = pad_to_multiple_of_64(V, seq_dim=1, num_pipeline=num_pipeline)
+    K_original = pad_to_multiple_of_64(K_original, seq_dim=1, num_pipeline=num_pipeline)
+    V_original = pad_to_multiple_of_64(V_original, seq_dim=1, num_pipeline=num_pipeline)
     O = pad_to_multiple_of_64(O, seq_dim=1, num_pipeline=num_pipeline)
 
     return {
         "Q": Q,
-        "K": K,
-        "V": V,
+        "K": K_original,
+        "V": V_original,
         "O": O,
     }

--- a/iron/operators/mha/test.py
+++ b/iron/operators/mha/test.py
@@ -81,7 +81,7 @@ def test_mha(
         num_KV_heads=num_kv_heads,
         num_of_pipelines=num_pipelines,
         context=aie_context,
-    )  # VJUNG: TODO: Pass the verbose flag to the operator for debugging
+    )
 
     input_buffers = {
         "Q": golden_ref["Q"].flatten(),

--- a/iron/operators/mha/test.py
+++ b/iron/operators/mha/test.py
@@ -13,8 +13,24 @@ from iron.common.test_utils import run_test
 
 
 def generate_test_params(extensive=False):
-    params = [(16384, 64, 1, 8)]
-    names = ["mha"]
+    # (seq_len, head_dim, heads, number_of_pipeline, num_kv_heads)
+
+    names = []
+
+    params = [
+                (16384, 64, 1, 8, 0)
+            ]
+
+    if extensive:
+        params += [
+                    (4096, 64, 8, 8, 4),
+                    (4096, 64, 8, 8, 2),
+                    (4096, 64, 8, 8, 0),
+                ]
+
+    for seq_len, head_dim, heads, number_of_pipeline, num_kv_heads in params:
+        names += [f"mha_{seq_len}_{head_dim}_{heads}_{number_of_pipeline}_{num_kv_heads}"]
+
     return params, names
 
 
@@ -35,14 +51,17 @@ all_params = [
     Latency=r"Latency \(us\): (?P<value>[\d\.]+)",
     Bandwidth=r"Effective Bandwidth: (?P<value>[\d\.e\+-]+) GB/s",
 )
-@pytest.mark.parametrize("seq_len,dim,num_heads,num_pipelines", all_params)
-def test_mha(seq_len, dim, num_heads, num_pipelines, aie_context):
+@pytest.mark.parametrize("seq_len,dim,num_heads,num_pipelines,num_kv_heads", all_params)
+def test_mha(seq_len: int, dim: int, num_heads: int, num_pipelines: int, num_kv_heads: int, aie_context):
+
+    print(f"\nTest configuration: seq_len={seq_len}, dim={dim}, num_heads={num_heads}, num_pipelines={num_pipelines}, num_kv_heads={num_kv_heads}")
+
     golden_ref = generate_golden_reference(
         S_q=seq_len,
         S_kv=seq_len,
         d=dim,
         heads=num_heads,
-        num_kv_heads=num_heads,
+        num_kv_heads=num_kv_heads,
         num_pipeline=num_pipelines,
     )
 
@@ -50,10 +69,10 @@ def test_mha(seq_len, dim, num_heads, num_pipelines, aie_context):
         num_heads=num_heads,
         seq_len=seq_len,
         d=dim,
-        num_KV_heads=num_heads,
+        num_KV_heads=num_kv_heads,
         num_of_pipelines=num_pipelines,
         context=aie_context,
-    )
+    ) # VJUNG: TODO: Pass the verbose flag to the operator for debugging
 
     input_buffers = {
         "Q": golden_ref["Q"].flatten(),

--- a/iron/operators/mha/test.py
+++ b/iron/operators/mha/test.py
@@ -17,19 +17,19 @@ def generate_test_params(extensive=False):
 
     names = []
 
-    params = [
-                (16384, 64, 1, 8, 0)
-            ]
+    params = [(16384, 64, 1, 8, 0)]
 
     if extensive:
         params += [
-                    (4096, 64, 8, 8, 4),
-                    (4096, 64, 8, 8, 2),
-                    (4096, 64, 8, 8, 0),
-                ]
+            (4096, 64, 8, 8, 4),
+            (4096, 64, 8, 8, 2),
+            (4096, 64, 8, 8, 0),
+        ]
 
     for seq_len, head_dim, heads, number_of_pipeline, num_kv_heads in params:
-        names += [f"mha_{seq_len}_{head_dim}_{heads}_{number_of_pipeline}_{num_kv_heads}"]
+        names += [
+            f"mha_{seq_len}_{head_dim}_{heads}_{number_of_pipeline}_{num_kv_heads}"
+        ]
 
     return params, names
 
@@ -52,9 +52,18 @@ all_params = [
     Bandwidth=r"Effective Bandwidth: (?P<value>[\d\.e\+-]+) GB/s",
 )
 @pytest.mark.parametrize("seq_len,dim,num_heads,num_pipelines,num_kv_heads", all_params)
-def test_mha(seq_len: int, dim: int, num_heads: int, num_pipelines: int, num_kv_heads: int, aie_context):
+def test_mha(
+    seq_len: int,
+    dim: int,
+    num_heads: int,
+    num_pipelines: int,
+    num_kv_heads: int,
+    aie_context,
+):
 
-    print(f"\nTest configuration: seq_len={seq_len}, dim={dim}, num_heads={num_heads}, num_pipelines={num_pipelines}, num_kv_heads={num_kv_heads}")
+    print(
+        f"\nTest configuration: seq_len={seq_len}, dim={dim}, num_heads={num_heads}, num_pipelines={num_pipelines}, num_kv_heads={num_kv_heads}"
+    )
 
     golden_ref = generate_golden_reference(
         S_q=seq_len,
@@ -72,7 +81,7 @@ def test_mha(seq_len: int, dim: int, num_heads: int, num_pipelines: int, num_kv_
         num_KV_heads=num_kv_heads,
         num_of_pipelines=num_pipelines,
         context=aie_context,
-    ) # VJUNG: TODO: Pass the verbose flag to the operator for debugging
+    )  # VJUNG: TODO: Pass the verbose flag to the operator for debugging
 
     input_buffers = {
         "Q": golden_ref["Q"].flatten(),

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -23,7 +23,7 @@ echo "Checking licenses with reuse..."
 if command -v reuse &> /dev/null; then
     if ! reuse lint; then
         echo "❌ License check failed"
-        echo '   Run: reuse annotate --template ApacheAMD --copyright-prefix spdx-string-c --copyright "Advanced Micro Devices, Inc. All rights reserved." --license="Apache-2.0" --recursive --skip-unrecognised ./
+        echo '   Run: reuse annotate --template ApacheAMD --copyright-prefix spdx-string-c --copyright "Advanced Micro Devices, Inc. All rights reserved." --license="Apache-2.0" --recursive --skip-unrecognised ./'
         FAILED=1
     else
         echo "✅ License check passed"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

#### Edit: Description by @hunhoffe

This PR optimizes and fixes the implementation of GQA (Grouped Query Attention) and adds testing for verification. It also improves the debugging experience by passing the `verbose` argument to the MLIR generator.

## Added
- Added `verbose` argument support to `AIEGEMV` operator and its MLIR generator (`my_matvec`).
- Added `verbose` flag passing from `AIEContext` to `AIEGEMV` and `AIEMHA` operators.

## Changed
- Updated `iron/operators/gemv/design.py` to accept and use `verbose` flag.
- Updated `iron/operators/gemv/op.py` to pass `mlir_verbose` from context to the generator.
- Updated `conftest.py` to pass `verbose` flag from pytest to `AIEContext`.

## Removed
-

## PR Merge Checklist

1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
