### PR TITLE
Add scale_i32_bf16 operator (int32 to bfloat16 with per-tensor scale)

### DIFF
--- a/aie_kernels/generic/scale_i32_bf16.cc
+++ b/aie_kernels/generic/scale_i32_bf16.cc
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <aie_api/aie.hpp>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Convert int32 to bfloat16 with scalar scale multiplication.
+// scale_tile contains 16 bfloat16 values; only the first is used (broadcast).
+// out[i] = bf16(float(in[i]) * float(scale_tile[0]))
+extern "C" {
+
+void scale_i32_to_bf16(int32_t *restrict in, bfloat16 *restrict scale_tile, bfloat16 *restrict out, int32_t size)
+{
+    float scale_f32 = (float)scale_tile[0];
+    aie::vector<float, 16> scale_vec = aie::broadcast<float, 16>(scale_f32);
+
+    event0();
+    for (int i = 0; i < size; i += 16) {
+        aie::vector<int32_t, 16> i32_vec = aie::load_v<16>(in + i);
+        aie::vector<float, 16> f32_vec = aie::to_float<float>(i32_vec, 0);
+        aie::vector<float, 16> scaled = aie::mul(f32_vec, scale_vec);
+        aie::accum<accfloat, 16> acc;
+        acc.from_vector(scaled, 0);
+        aie::store_v(out + i, acc.to_vector<bfloat16>());
+    }
+    event1();
+}
+
+} // extern "C"

--- a/iron/operators/scale_i32_bf16/design.py
+++ b/iron/operators/scale_i32_bf16/design.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from ml_dtypes import bfloat16
+import numpy as np
+
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron.placers import SequentialPlacer
+from aie.helpers.taplib.tap import TensorAccessPattern
+from aie.iron.controlflow import range_
+
+
+def my_scale_i32_bf16_kernel(
+    dev,
+    num_elements,
+    num_columns,
+    num_channels,
+    trace_size,
+    tile_size,
+):
+    # Cap tile size for L1 memory: i32 input (tile*4B) + bf16 output (tile*2B) + scale (32B)
+    per_tile_elements = 8192 if tile_size > 8192 else tile_size
+    total_cores = num_columns * num_channels
+    per_core_elements = num_elements // total_cores
+    if num_elements % total_cores != 0:
+        raise ValueError(
+            f"Number of elements ({num_elements}) must be a multiple of {total_cores}."
+        )
+    N_div_n = per_core_elements // per_tile_elements
+
+    # Types
+    data_tile_ty = np.ndarray[(per_tile_elements,), np.dtype[np.int32]]
+    data_tensor_ty = np.ndarray[(num_elements,), np.dtype[np.int32]]
+    scale_tile_ty = np.ndarray[(16,), np.dtype[bfloat16]]  # 16 for DMA alignment
+    scale_tensor_ty = np.ndarray[(total_cores * 16,), np.dtype[bfloat16]]
+    out_tile_ty = np.ndarray[(per_tile_elements,), np.dtype[bfloat16]]
+    out_tensor_ty = np.ndarray[(num_elements,), np.dtype[bfloat16]]
+
+    fifodepth = 1 if tile_size > 4096 else 2
+    enable_trace = trace_size > 0
+
+    # ObjectFIFOs
+    of_ins = [
+        ObjectFifo(data_tile_ty, name=f"in_{i}_{j}", depth=fifodepth)
+        for i in range(num_columns)
+        for j in range(num_channels)
+    ]
+    of_scales = [
+        ObjectFifo(scale_tile_ty, name=f"scale_{i}_{j}", depth=1)
+        for i in range(num_columns)
+        for j in range(num_channels)
+    ]
+    of_outs = [
+        ObjectFifo(out_tile_ty, name=f"out_{i}_{j}", depth=fifodepth)
+        for i in range(num_columns)
+        for j in range(num_channels)
+    ]
+
+    # Kernel
+    scale_kernel = Kernel(
+        "scale_i32_to_bf16",
+        f"scale_i32_bf16_{tile_size}.o",
+        [data_tile_ty, scale_tile_ty, out_tile_ty, np.int32],
+    )
+
+    # Core task: acquire scale once, process all tiles
+    def core_body(of_in, of_scale, of_out, kernel):
+        elem_scale = of_scale.acquire(1)
+        for _ in range_(N_div_n):
+            elem_in = of_in.acquire(1)
+            elem_out = of_out.acquire(1)
+            kernel(elem_in, elem_scale, elem_out, per_tile_elements)
+            of_in.release(1)
+            of_out.release(1)
+        of_scale.release(1)
+
+    # Workers
+    my_workers = [
+        Worker(
+            core_body,
+            [
+                of_ins[i * num_channels + j].cons(),
+                of_scales[i * num_channels + j].cons(),
+                of_outs[i * num_channels + j].prod(),
+                scale_kernel,
+            ],
+        )
+        for i in range(num_columns)
+        for j in range(num_channels)
+    ]
+
+    # TensorAccessPatterns
+    chunk = num_elements // total_cores  # elements per core
+    data_taps = [
+        TensorAccessPattern(
+            (1, num_elements),
+            chunk * (i * num_channels + j),
+            [1, 1, 1, chunk],
+            [0, 0, 0, 1],
+        )
+        for i in range(num_columns)
+        for j in range(num_channels)
+    ]
+    scale_taps = [
+        TensorAccessPattern(
+            (1, total_cores * 16),
+            16 * (i * num_channels + j),
+            [1, 1, 1, 16],
+            [0, 0, 0, 1],
+        )
+        for i in range(num_columns)
+        for j in range(num_channels)
+    ]
+
+    # Runtime
+    rt = Runtime()
+    with rt.sequence(data_tensor_ty, scale_tensor_ty, out_tensor_ty) as (A, S, C):
+        if enable_trace:
+            rt.enable_trace(trace_size)
+        rt.start(*my_workers)
+
+        tg = rt.task_group()
+        for i in range(num_columns):
+            for j in range(num_channels):
+                idx = i * num_channels + j
+                rt.fill(of_ins[idx].prod(), A, data_taps[idx], task_group=tg)
+                rt.fill(of_scales[idx].prod(), S, scale_taps[idx], task_group=tg)
+        for i in range(num_columns):
+            for j in range(num_channels):
+                idx = i * num_channels + j
+                rt.drain(
+                    of_outs[idx].cons(),
+                    C,
+                    data_taps[idx],
+                    wait=True,
+                    task_group=tg,
+                )
+        rt.finish_task_group(tg)
+
+    return Program(dev, rt).resolve_program(SequentialPlacer())

--- a/iron/operators/scale_i32_bf16/op.py
+++ b/iron/operators/scale_i32_bf16/op.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass, field
+
+import numpy as np
+from ml_dtypes import bfloat16
+
+from iron.common import (
+    MLIROperator,
+    AIERuntimeArgSpec,
+    KernelObjectArtifact,
+    SourceArtifact,
+    PythonGeneratedMLIRArtifact,
+    DesignGenerator,
+)
+import aie.utils as aie_utils
+
+
+@dataclass
+class ScaleI32(MLIROperator):
+    """AIE-accelerated int32 to bfloat16 conversion with per-tensor scale.
+
+    Designed to compose directly with INT8 GEMM output — no packed buffer formats.
+    Each element: out[i] = bf16(float(in_i32[i]) * scale)
+    """
+
+    size: int
+    num_aie_columns: int
+    num_channels: int
+    tile_size: int
+    context: object = field(default=None, repr=False)
+
+    def __post_init__(self):
+        total_cores = self.num_aie_columns * self.num_channels
+        if self.size % self.tile_size != 0:
+            raise ValueError(
+                f"size ({self.size}) must be divisible by tile_size ({self.tile_size})"
+            )
+        if self.size % total_cores != 0:
+            raise ValueError(
+                f"size ({self.size}) must be divisible by total cores ({total_cores})"
+            )
+        if total_cores > 8:
+            raise ValueError(f"total cores ({total_cores}) must be <= 8")
+        if self.tile_size % 16 != 0:
+            raise ValueError(f"tile_size ({self.tile_size}) must be a multiple of 16")
+        self.total_cores = total_cores
+        # Scale buffer: 16 bf16 values per core (for DMA alignment)
+        self.scale_size = total_cores * 16
+        MLIROperator.__init__(self, context=self.context)
+
+    def get_mlir_artifact(self):
+        return PythonGeneratedMLIRArtifact(
+            f"{self.name}.mlir",
+            DesignGenerator(
+                self.operator_dir / "design.py",
+                "my_scale_i32_bf16_kernel",
+                (
+                    aie_utils.get_current_device(),
+                    self.size,
+                    self.num_aie_columns,
+                    self.num_channels,
+                    0,  # trace_size
+                    self.tile_size,
+                ),
+            ),
+        )
+
+    def get_kernel_artifacts(self):
+        return [
+            KernelObjectArtifact(
+                f"scale_i32_bf16_{self.tile_size}.o",
+                dependencies=[
+                    SourceArtifact(
+                        self.context.base_dir
+                        / "aie_kernels"
+                        / "generic"
+                        / "scale_i32_bf16.cc"
+                    )
+                ],
+                extra_flags=[],
+            )
+        ]
+
+    def get_arg_spec(self):
+        return [
+            AIERuntimeArgSpec("in", (self.size,), dtype=np.int32),
+            AIERuntimeArgSpec("in", (self.scale_size,), dtype=bfloat16),
+            AIERuntimeArgSpec("out", (self.size,), dtype=bfloat16),
+        ]

--- a/iron/operators/scale_i32_bf16/reference.py
+++ b/iron/operators/scale_i32_bf16/reference.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import numpy as np
+from ml_dtypes import bfloat16
+
+
+def generate_golden_reference(input_length, tile_size, num_aie_columns, num_channels):
+    """Generate test data and golden reference for scale_i32_bf16 operator.
+
+    Returns dict with:
+        input_i32: flat int32 tensor (simulating GEMM output)
+        scale: scalar float scale value
+        scale_buffer: bf16 buffer with scale repeated (total_cores * 16)
+        expected_output: flat bf16 tensor
+    """
+    total_cores = num_aie_columns * num_channels
+
+    # Random int32 values in typical GEMM accumulator range
+    input_i32 = torch.randint(-200000, 200000, (input_length,), dtype=torch.int32)
+
+    # Random scale in typical range (scale_A * scale_W)
+    scale = np.random.uniform(1e-6, 1e-3)
+
+    # Scale buffer: same value repeated, 16 per core for DMA alignment
+    scale_buffer = np.full(total_cores * 16, scale, dtype=np.float32).astype(bfloat16)
+
+    # Reference computation: float(i32) * scale -> bf16
+    # Use the bf16 scale value (after conversion) for the reference to match hardware
+    scale_as_bf16 = float(bfloat16(np.float32(scale)))
+    expected = (input_i32.float() * scale_as_bf16).to(torch.bfloat16)
+
+    return {
+        "input_i32": input_i32,
+        "scale": scale,
+        "scale_buffer": torch.from_numpy(scale_buffer.view(np.uint16)).view(
+            torch.bfloat16
+        ),
+        "expected_output": expected,
+    }

--- a/iron/operators/scale_i32_bf16/test.py
+++ b/iron/operators/scale_i32_bf16/test.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import aie.utils as aie_utils
+
+from iron.operators.scale_i32_bf16.op import ScaleI32
+from iron.operators.scale_i32_bf16.reference import generate_golden_reference
+from iron.common.test_utils import run_test
+
+
+def get_params():
+    max_aie_columns = aie_utils.get_current_device().cols
+
+    input_lengths = [1024, 2048, 4096, 8192]
+
+    params = []
+    for input_length in input_lengths:
+        for num_columns in range(1, max_aie_columns + 1):
+            for num_channels in range(1, 3):  # 1 or 2 channels
+                total_cores = num_columns * num_channels
+                # 3 ObjectFIFOs per core (data_in, scale, data_out) limits placement
+                if total_cores > 8:
+                    continue
+                if input_length % total_cores != 0:
+                    continue
+
+                tile_size = input_length // total_cores
+
+                # Cap tile_size at 8192
+                if tile_size > 8192:
+                    tile_size = 8192
+
+                # Only proceed if exact division
+                if tile_size * total_cores != input_length:
+                    continue
+
+                # Ensure tile_size is a multiple of 16
+                if tile_size % 16 != 0:
+                    continue
+
+                is_regular = input_length == 2048
+                marks = [] if is_regular else [pytest.mark.extensive]
+
+                params.append(
+                    pytest.param(
+                        input_length,
+                        num_columns,
+                        num_channels,
+                        tile_size,
+                        marks=marks,
+                    )
+                )
+    return params
+
+
+@pytest.mark.metrics(
+    Latency=r"Latency \(us\): (?P<value>[\d\.]+)",
+    Bandwidth=r"Effective Bandwidth: (?P<value>[\d\.e\+-]+) GB/s",
+)
+@pytest.mark.parametrize(
+    "input_length,num_aie_columns,num_channels,tile_size",
+    get_params(),
+)
+def test_scale_i32_bf16(
+    input_length, num_aie_columns, num_channels, tile_size, aie_context
+):
+    golden_ref = generate_golden_reference(
+        input_length=input_length,
+        tile_size=tile_size,
+        num_aie_columns=num_aie_columns,
+        num_channels=num_channels,
+    )
+
+    operator = ScaleI32(
+        size=input_length,
+        num_aie_columns=num_aie_columns,
+        num_channels=num_channels,
+        tile_size=tile_size,
+        context=aie_context,
+    )
+
+    input_buffers = {
+        "data": golden_ref["input_i32"].flatten(),
+        "scale": golden_ref["scale_buffer"].flatten(),
+    }
+    output_buffers = {"output": golden_ref["expected_output"].flatten()}
+
+    errors, latency_us, bandwidth_gbps = run_test(
+        operator, input_buffers, output_buffers, rel_tol=0.01, abs_tol=1e-6
+    )
+
+    print(f"\nLatency (us): {latency_us:.1f}")
+    print(f"Effective Bandwidth: {bandwidth_gbps:.6e} GB/s\n")
+
+    assert not errors, f"Test failed with errors: {errors}"


### PR DESCRIPTION
## Added
    - `aie_kernels/generic/scale_i32_bf16.cc` : C++ AIE kernel that converts int32 to bfloat16 with scalar scale multiplication. Uses the proven `aie::to_float` + `acc.to_vector<bfloat16>()` conversion pattern.
    - `iron/operators/scale_i32_bf16/` : Python operator (op.py, design.py, reference.py, test.py).

  ## Changed
    Nothing. This is a new operator with no modifications to existing code.

  ## Removed
    Nothing.

  ## Motivation
    The existing `dequant_i32_bf16` operator uses per-group packed buffer formats (`[i32_data | bf16_scales]` as uint8) that don't compose directly with INT8 GEMM output. CPU-side dequantization requires expensive NPU↔CPU round trips (16MB i32 download + 8MB bf16 upload per GEMM call).

    This operator takes plain typed buffers, int32 input directly from GEMM, a tiny bf16 scale buffer (~256 bytes), and bf16 output, enabling fully on-NPU i32→bf16 dequantization with zero CPU round trips.

    Key design: the scale ObjectFIFO is acquired once per core and held across all tile iterations, so the scale buffer stays minimal (num_cores × 16 bf16 values) regardless of tensor size. Wins over CPU dequant at prompt lengths ≥ ~3500 tokens.

  ## Test results
    - 28/28 parametrized tests pass (input lengths 1K–8K, 1–8 columns, 1–2 channels, tile sizes 128–8192)
    - rel_tol=0.01, abs_tol=1e-6 (matches dequant_i32_bf16 tolerances)
    - No regressions in existing operators

  ## Checklist
    - [x] Tests pass locally (28/28 including extensive)
    - [x] Code formatted (black + clang-format)
    - [x] License headers on all files
    - [x] No changes to existing code

  Closes #99 