### PR TITLE
Restore device-aware num_aie_columns in SwiGLU operators

### DIFF
--- a/iron/operators/swiglu_decode/op.py
+++ b/iron/operators/swiglu_decode/op.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import aie.utils as aie_utils
+
 from iron.common import (
     CompositeOperator,
     AIERuntimeArgSpec,
@@ -39,27 +41,33 @@ class SwiGLUDecode(CompositeOperator):
         super().__init__(context=context)
 
     def set_up_artifacts(self):
+        # Use the full column count available on the target device: 4 on NPU1
+        # (Phoenix, aie2) and 8 on NPU2 (Strix, aie2p). Restores NPU1 support
+        # that was originally added in #89 and inadvertently dropped during the
+        # simplifying refactor (#88).
+        n_cols = aie_utils.get_current_device().cols
+
         gemv_1 = GEMV(
             M=self.hidden_dim,
             K=self.embedding_dim,
-            num_aie_columns=8,
+            num_aie_columns=n_cols,
             tile_size_input=4,
-            tile_size_output=self.hidden_dim // 8,
+            tile_size_output=self.hidden_dim // n_cols,
         )
         self.gemv_1 = gemv_1
 
         silu = SiLU(
             size=self.hidden_dim,
-            num_aie_columns=8,
-            tile_size=self.hidden_dim // (8 * 2),
+            num_aie_columns=n_cols,
+            tile_size=self.hidden_dim // (n_cols * 2),
         )
         self.silu = silu
         self.hidden_dim_padded = silu.size
 
         eltwise_mul = ElementwiseMul(
             size=self.hidden_dim,
-            num_aie_columns=8,
-            tile_size=self.hidden_dim // 8,
+            num_aie_columns=n_cols,
+            tile_size=self.hidden_dim // n_cols,
         )
         self.eltwise_mul = eltwise_mul
         assert self.hidden_dim <= eltwise_mul.size <= self.hidden_dim_padded
@@ -67,9 +75,9 @@ class SwiGLUDecode(CompositeOperator):
         gemv_2 = GEMV(
             M=self.embedding_dim,
             K=self.hidden_dim,
-            num_aie_columns=8,
+            num_aie_columns=n_cols,
             tile_size_input=1,
-            tile_size_output=self.embedding_dim // 8,
+            tile_size_output=self.embedding_dim // n_cols,
         )
         self.gemv_2 = gemv_2
 

--- a/iron/operators/swiglu_prefill/op.py
+++ b/iron/operators/swiglu_prefill/op.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import aie.utils as aie_utils
+
 from iron.common import (
     CompositeOperator,
     AIERuntimeArgSpec,
@@ -45,6 +47,13 @@ class SwiGLUPrefill(CompositeOperator):
         # All operators (GEMM, SiLU, ElementwiseMul) apply their own padding
         # to meet hardware alignment requirements. We store the padded dimensions
         # from GEMM and verify that all operators use consistent padded sizes.
+        #
+        # Use the full column count available on the target device: 4 on NPU1
+        # (Phoenix, aie2) and 8 on NPU2 (Strix, aie2p). Restores NPU1 support
+        # that was originally added in #89 and inadvertently dropped during the
+        # simplifying refactor (#88).
+        n_cols = aie_utils.get_current_device().cols
+
         accuracy_flags = {}
         if self.prio_accuracy:
             accuracy_flags = {
@@ -54,7 +63,11 @@ class SwiGLUPrefill(CompositeOperator):
             }
 
         gemm_1 = GEMM(
-            M=self.seq_len, K=self.embedding_dim, N=self.hidden_dim, **accuracy_flags
+            M=self.seq_len,
+            K=self.embedding_dim,
+            N=self.hidden_dim,
+            num_aie_columns=n_cols,
+            **accuracy_flags,
         )
         self.gemm_1 = gemm_1
         self.seq_len_padded = gemm_1.M
@@ -63,22 +76,26 @@ class SwiGLUPrefill(CompositeOperator):
 
         silu = SiLU(
             size=self.seq_len_padded * self.hidden_dim_padded,
-            num_aie_columns=8,
-            tile_size=self.hidden_dim_padded // 8,
+            num_aie_columns=n_cols,
+            tile_size=self.hidden_dim_padded // n_cols,
         )
         self.silu = silu
         assert silu.size == self.seq_len_padded * self.hidden_dim_padded
 
         eltwise_mul = ElementwiseMul(
             size=self.seq_len_padded * self.hidden_dim_padded,
-            num_aie_columns=8,
-            tile_size=self.hidden_dim_padded // 8,
+            num_aie_columns=n_cols,
+            tile_size=self.hidden_dim_padded // n_cols,
         )
         self.eltwise_mul = eltwise_mul
         assert eltwise_mul.size == self.seq_len_padded * self.hidden_dim_padded
 
         gemm_2 = GEMM(
-            M=self.seq_len, K=self.hidden_dim, N=self.embedding_dim, **accuracy_flags
+            M=self.seq_len,
+            K=self.hidden_dim,
+            N=self.embedding_dim,
+            num_aie_columns=n_cols,
+            **accuracy_flags,
         )
         self.gemm_2 = gemm_2
         assert gemm_2.M == self.seq_len_padded

--- a/iron/operators/swiglu_prefill/test.py
+++ b/iron/operators/swiglu_prefill/test.py
@@ -17,7 +17,14 @@ from iron.common.test_utils import verify_buffer
 
 
 def get_params():
-    params_list = [(256, 2048, 2048, False)]
+    # (seq_len, embedding_dim, hidden_dim, prio_accuracy)
+    # Square shapes cover the historical smoke-test config; rectangular
+    # shapes reflect real decoder-model FFN dims (e.g. Qwen3.5-0.8B
+    # embedding=1024, hidden=3584) that downstream runtimes actually hit.
+    params_list = [
+        (256, 2048, 2048, False),
+        (256, 1024, 3584, False),
+    ]
 
     params = []
     for p in params_list:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

Restores device-aware column selection in `SwiGLUDecode` and `SwiGLUPrefill` so both composite operators run on Phoenix (NPU1, 4 columns) as well as Strix (NPU2, 8 columns). The branching was originally introduced in #89 and inadvertently dropped during the simplifying refactor in #88, which hardcoded `num_aie_columns=8` across both SwiGLU variants. This PR replaces the literal `8` with `aie_utils.get_current_device().cols`, matching the pattern already used by `rms_norm`, `gemm`, `gemv`, `mem_copy`, etc.

  While re-threading the column count, `num_aie_columns=n_cols` is also now passed to the two `GEMM` calls in `SwiGLUPrefill`. Previously those defaulted to `GEMM`'s fallback, which meant SwiGLU prefill was implicitly under-parallelized on NPU2 and misaligned with the column count used by the surrounding SiLU and ElementwiseMul sub-ops.

  A new rectangular FFN shape (`seq_len=256, embedding_dim=1024, hidden_dim=3584`) is added to `swiglu_prefill/test.py` so real decoder-model FFN dimensions (e.g. Qwen3.5-0.8B) are exercised in CI alongside the existing square `2048² ` smoke test.

  ## Added
  - `(256, 1024, 3584, False)` rectangular FFN shape in `iron/operators/swiglu_prefill/test.py`, reflecting real decoder-model dims so non-square paths are covered.

  ## Changed
  - `iron/operators/swiglu_decode/op.py`: derive `n_cols = aie_utils.get_current_device().cols` and pass it to the gemv_1 / silu / eltwise_mul / gemv_2 sub-ops in place of the hardcoded `8`.
  - `iron/operators/swiglu_prefill/op.py`: same device-aware derivation, applied to silu / eltwise_mul and (newly) threaded through the `gemm_1` and `gemm_2` calls, which previously omitted `num_aie_columns` entirely.

  ## Removed
  - Hardcoded `num_aie_columns=8` and associated `// 8`, `// 16` literals in both SwiGLU op files.

  ## Testing
  Verified on NPU2 (Strix, `aie2p`) with `ironenv` + XRT sourced:

  - `pytest iron/operators/ -m "not extensive" --iterations 1` : all previously-passing tests still pass (pre-existing LeakyReLU skips unchanged).
  - `pytest iron/operators/swiglu_decode/test.py -v --iterations 1` : square `2048² ` passes.
  - `pytest iron/operators/swiglu_prefill/test.py -v --iterations 1` : both square `2048² ` and the new rectangular `256 × 1024 × 3584` pass.

  NPU1 (Phoenix, `aie2`) hardware was not available for local validation; the column-selection logic is structurally identical to the previously-shipped #89 code path, so Phoenix behavior is expected to match that baseline and should be re-confirmed by a reviewer with Phoenix access.

  During this work a separate, pre-existing numerical issue was observed in `swiglu_decode` at rectangular decode shapes (e.g. `1024 × 3584`) that is unrelated to this change, the decode failure reproduces with `num_aie_columns=8` either before or after this PR, so the rectangular case was not added to `swiglu_decode/test.py` in this PR. That issue is being investigated separately.

  ## PR Merge Checklist

  1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
  2. [ ] Your PR has been reviewed and approved.
  3. [ ] All checks are passing.