### PR TITLE
Switch to native 512b vectors to improve performance

### DIFF
--- a/aie_kernels/aie2/gelu.cc
+++ b/aie_kernels/aie2/gelu.cc
@@ -9,52 +9,50 @@
 
 using namespace aie;
 
+// GELU (tanh approximation): 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3))).
+// Same MAC-fused structure as the aie2p kernel, but tanh uses the LUT-based
+// implementation (aie2 has no native bf16 tanh):
+//   inner1 = s*x + s_beta*x*x^2  (single MAC, instead of mul+add+mul)
+//   result = mac(0.5x, tanh, 0.5x)  (single MAC, instead of add+mul+mul)
+static inline aie::vector<bfloat16, 32> gelu_tanh_approx(aie::vector<bfloat16, 32> x)
+{
+    const bfloat16 k0_5 = 0.5f;
+    const bfloat16 sqrt_2_over_pi = 0.79788456f; // sqrt(2/pi)
+    const bfloat16 s_beta = sqrt_2_over_pi * 0.044715f; // precomputed s*beta
+
+    auto v05 = aie::broadcast<bfloat16, 32>(k0_5);
+    auto vs2opi = aie::broadcast<bfloat16, 32>(sqrt_2_over_pi);
+    auto vsBeta = aie::broadcast<bfloat16, 32>(s_beta);
+
+    aie::vector<bfloat16, 32> x2 = aie::mul(x, x).to_vector<bfloat16>();
+    aie::vector<bfloat16, 32> sbeta_x = aie::mul(x, vsBeta).to_vector<bfloat16>();
+    auto sx = aie::mul(x, vs2opi);
+    auto half_x = aie::mul(x, v05);
+
+    aie::vector<bfloat16, 32> inner1 = aie::mac(sx, sbeta_x, x2).to_vector<bfloat16>();
+
+    // LUT-based tanh: split to 16-wide halves
+    aie::vector<bfloat16, 16> tanh_lo = getTanhBf16(inner1.extract<16>(0));
+    aie::vector<bfloat16, 16> tanh_hi = getTanhBf16(inner1.extract<16>(1));
+    aie::vector<bfloat16, 32> tanh_out = aie::concat(tanh_lo, tanh_hi);
+
+    return aie::mac(half_x, tanh_out, half_x.to_vector<bfloat16>()).to_vector<bfloat16>();
+}
+
 void gelu_tanh_approx_bf16(bfloat16 *restrict input_vector, bfloat16 *restrict output_vector, const int32_t vector_size)
 {
     event0();
 
-    auto it_in = aie::begin_restrict_vector<16>((bfloat16 *)input_vector);
-    auto it_out = aie::begin_restrict_vector<16>((bfloat16 *)output_vector);
+    auto it_in = aie::begin_restrict_vector<32>((bfloat16 *)input_vector);
+    auto it_out = aie::begin_restrict_vector<32>((bfloat16 *)output_vector);
 
-    aie::vector<bfloat16, 16> input;
-
-    // Constants
-    const bfloat16 k0_5 = 0.5f;
-    const bfloat16 k1 = 1.0f;
-    const bfloat16 sqrt_2_over_pi = 0.79788456f; // ≈ sqrt(2/π)
-    const bfloat16 kBeta = 0.044715f;
-
-    auto v05 = aie::broadcast<bfloat16, 16>(k0_5);
-    auto v1 = aie::broadcast<bfloat16, 16>(k1);
-    auto vs2opi = aie::broadcast<bfloat16, 16>(sqrt_2_over_pi);
-    auto vBeta = aie::broadcast<bfloat16, 16>(kBeta);
-
-    AIE_PREPARE_FOR_PIPELINING
-    AIE_LOOP_MIN_ITERATION_COUNT(64)
-    for (int i = 0; i < vector_size; i += 16) {
-        input = *it_in++;
-        auto x = input;
-
-        // Compute x^3
-        aie::vector<bfloat16, 16> x2 = aie::mul(x, x);  // x^2
-        aie::vector<bfloat16, 16> x3 = aie::mul(x, x2); // x^3
-
-        // inner = sqrt(2/pi) * (x + 0.044715 * x^3)
-        aie::vector<bfloat16, 16> x3_beta = aie::mul(x3, vBeta);
-        aie::vector<bfloat16, 16> inner = aie::add(x, x3_beta);
-        auto inner1 = aie::mul(inner, vs2opi);
-
-        // tanh_out = tanh(inner)
-        aie::vector<bfloat16, 16> tanh_out = getTanhBf16(inner1.to_vector<bfloat16>());
-
-        // result = 0.5 * x * (1 + tanh_out)
-        aie::vector<bfloat16, 16> one_plus_tanh = aie::add(tanh_out, v1);
-        // Multiply by x and 0.5
-        aie::vector<bfloat16, 16> mul_v05 = aie::mul(v05, one_plus_tanh);
-        auto result = aie::mul(x, mul_v05);
-
-        *it_out++ = result.to_vector<bfloat16>();
-    }
+    // AIE_PREPARE_FOR_POSTPIPELINING kept for parity with the aie2p kernel. On aie2
+    // neither pipeliner finds a schedule (LUT tanh register pressure), but the
+    // MAC-fused body still reduces II from 129 to 87 cycles per 32 elements.
+    auto body = [&]() __attribute__((always_inline)) {
+        *it_out++ = gelu_tanh_approx(*it_in++);
+    };
+    VERSIONED_LOOP(2, (vector_size + 31) / 32, body, AIE_PREPARE_FOR_POSTPIPELINING);
 
     event1();
 

--- a/aie_kernels/aie2/gelu.cc
+++ b/aie_kernels/aie2/gelu.cc
@@ -17,7 +17,7 @@ using namespace aie;
 static inline aie::vector<bfloat16, 32> gelu_tanh_approx(aie::vector<bfloat16, 32> x)
 {
     const bfloat16 k0_5 = 0.5f;
-    const bfloat16 sqrt_2_over_pi = 0.79788456f; // sqrt(2/pi)
+    const bfloat16 sqrt_2_over_pi = 0.79788456f;        // sqrt(2/pi)
     const bfloat16 s_beta = sqrt_2_over_pi * 0.044715f; // precomputed s*beta
 
     auto v05 = aie::broadcast<bfloat16, 32>(k0_5);
@@ -49,7 +49,8 @@ void gelu_tanh_approx_bf16(bfloat16 *restrict input_vector, bfloat16 *restrict o
     // AIE_PREPARE_FOR_POSTPIPELINING kept for parity with the aie2p kernel. On aie2
     // neither pipeliner finds a schedule (LUT tanh register pressure), but the
     // MAC-fused body still reduces II from 129 to 87 cycles per 32 elements.
-    auto body = [&]() __attribute__((always_inline)) {
+    auto body = [&]() __attribute__((always_inline))
+    {
         *it_out++ = gelu_tanh_approx(*it_in++);
     };
     VERSIONED_LOOP(2, (vector_size + 31) / 32, body, AIE_PREPARE_FOR_POSTPIPELINING);

--- a/aie_kernels/aie2/relu.cc
+++ b/aie_kernels/aie2/relu.cc
@@ -15,7 +15,7 @@ void relu_vectorized_bf16(bfloat16 *restrict a, bfloat16 *restrict c, const int3
 {
     event0();
 
-    const int v_factor = 16;
+    const int v_factor = 32;
     v32bfloat16 zeroes = broadcast_zero_to_v32bfloat16();
     AIE_PREPARE_FOR_PIPELINING
     AIE_LOOP_RANGE(16, 16)

--- a/aie_kernels/aie2/rms_norm.cc
+++ b/aie_kernels/aie2/rms_norm.cc
@@ -74,12 +74,12 @@ extern "C" {
 void rms_norm_bf16_vector(bfloat16 *input, bfloat16 *output, int32_t size, float epsilon)
 {
     ::aie::set_rounding(aie::rounding_mode::conv_even); // round-to-nearest-even
-    rms_norm_general<bfloat16, 16>(input, nullptr, output, size, epsilon);
+    rms_norm_general<bfloat16, 32>(input, nullptr, output, size, epsilon);
 }
 
 void weighted_rms_norm(bfloat16 *a_in, bfloat16 *b_in, bfloat16 *c_out, int32_t size, float epsilon)
 {
     ::aie::set_rounding(aie::rounding_mode::conv_even); // round-to-nearest-even
-    rms_norm_general<bfloat16, 16>(a_in, b_in, c_out, size, epsilon);
+    rms_norm_general<bfloat16, 32>(a_in, b_in, c_out, size, epsilon);
 }
 }

--- a/aie_kernels/aie2/sigmoid.cc
+++ b/aie_kernels/aie2/sigmoid.cc
@@ -15,24 +15,27 @@ void sigmoid_tanh_approx_bf16(bfloat16 *restrict input_vector,
 {
     event0();
 
-    auto it_in = aie::begin_restrict_vector<16>((bfloat16 *)input_vector);
-    auto it_out = aie::begin_restrict_vector<16>((bfloat16 *)output_vector);
+    auto it_in = aie::begin_restrict_vector<32>((bfloat16 *)input_vector);
+    auto it_out = aie::begin_restrict_vector<32>((bfloat16 *)output_vector);
 
-    aie::vector<bfloat16, 16> register_0_5 = aie::broadcast<bfloat16, 16>(0.5f);
-    aie::vector<bfloat16, 16> register_1 = aie::broadcast<bfloat16, 16>(1.0f);
+    aie::vector<bfloat16, 32> register_0_5 = aie::broadcast<bfloat16, 32>(0.5f);
+    aie::vector<bfloat16, 32> register_1 = aie::broadcast<bfloat16, 32>(1.0f);
     AIE_PREPARE_FOR_PIPELINING
     AIE_LOOP_MIN_ITERATION_COUNT(64)
-    for (int i = 0; i < vector_size; i += 16) {
-        // Load input vector
-        aie::vector<bfloat16, 16> input = *it_in++;
+    for (int i = 0; i < vector_size; i += 32) {
+        auto input = *it_in++;
 
-        // Compute tanh approximation
-        aie::vector<bfloat16, 16> half_x = aie::mul(input, register_0_5);
-        aie::vector<bfloat16, 16> tanh_half_x = getTanhBf16(half_x);
-        auto tanh_half_x_approx = aie::add(tanh_half_x, register_1);
-        aie::vector<bfloat16, 16> sigmoid_approx = aie::mul(tanh_half_x_approx, register_0_5);
+        // Compute half_x = x * 0.5
+        aie::vector<bfloat16, 32> half_x = aie::mul(input, register_0_5);
 
-        // Store output vector
+        // LUT-based tanh: split to 16-wide halves
+        aie::vector<bfloat16, 16> tanh_lo = getTanhBf16(half_x.extract<16>(0));
+        aie::vector<bfloat16, 16> tanh_hi = getTanhBf16(half_x.extract<16>(1));
+        aie::vector<bfloat16, 32> tanh_half_x = aie::concat(tanh_lo, tanh_hi);
+
+        auto one_plus = aie::add(tanh_half_x, register_1);
+        aie::vector<bfloat16, 32> sigmoid_approx = aie::mul(one_plus, register_0_5);
+
         *it_out++ = sigmoid_approx;
     }
 

--- a/aie_kernels/aie2/silu.cc
+++ b/aie_kernels/aie2/silu.cc
@@ -13,26 +13,28 @@ void silu_tanh_approx_bf16(bfloat16 *restrict input_vector, bfloat16 *restrict o
 {
     event0();
 
-    auto it_in = aie::begin_restrict_vector<16>((bfloat16 *)input_vector);
-    auto it_out = aie::begin_restrict_vector<16>((bfloat16 *)output_vector);
+    auto it_in = aie::begin_restrict_vector<32>((bfloat16 *)input_vector);
+    auto it_out = aie::begin_restrict_vector<32>((bfloat16 *)output_vector);
 
-    aie::vector<bfloat16, 16> register_0_5 = aie::broadcast<bfloat16, 16>(0.5f);
-    aie::vector<bfloat16, 16> register_1 = aie::broadcast<bfloat16, 16>(1.0f);
+    aie::vector<bfloat16, 32> register_0_5 = aie::broadcast<bfloat16, 32>(0.5f);
+    aie::vector<bfloat16, 32> register_1 = aie::broadcast<bfloat16, 32>(1.0f);
     AIE_PREPARE_FOR_PIPELINING
     AIE_LOOP_MIN_ITERATION_COUNT(64)
-    for (int i = 0; i < vector_size; i += 16) {
-        // Load input vector
-        aie::vector<bfloat16, 16> input = *it_in++;
+    for (int i = 0; i < vector_size; i += 32) {
+        auto input = *it_in++;
 
-        // Compute tanh approximation
-        aie::vector<bfloat16, 16> half_x = aie::mul(input, register_0_5);
-        aie::vector<bfloat16, 16> tanh_half_x = getTanhBf16(half_x);
-        auto tanh_half_x_approx = aie::add(tanh_half_x, register_1);
-        aie::vector<bfloat16, 16> sigmoid_approx = aie::mul(tanh_half_x_approx, register_0_5);
-        // Compute output: x * tanh_approx
+        // Compute half_x = x * 0.5
+        aie::vector<bfloat16, 32> half_x = aie::mul(input, register_0_5);
+
+        // LUT-based tanh: split to 16-wide halves
+        aie::vector<bfloat16, 16> tanh_lo = getTanhBf16(half_x.extract<16>(0));
+        aie::vector<bfloat16, 16> tanh_hi = getTanhBf16(half_x.extract<16>(1));
+        aie::vector<bfloat16, 32> tanh_half_x = aie::concat(tanh_lo, tanh_hi);
+
+        auto one_plus = aie::add(tanh_half_x, register_1);
+        aie::vector<bfloat16, 32> sigmoid_approx = aie::mul(one_plus, register_0_5);
         auto mul_output = aie::mul(input, sigmoid_approx);
 
-        // Store output vector
         *it_out++ = mul_output.to_vector<bfloat16>();
     }
 

--- a/aie_kernels/aie2/tanh.cc
+++ b/aie_kernels/aie2/tanh.cc
@@ -13,20 +13,19 @@ void tanh_bf16_vectorized(bfloat16 *restrict input_vector, bfloat16 *restrict ou
 {
     event0();
 
-    auto it_in = aie::begin_restrict_vector<16>((bfloat16 *)input_vector);
-    auto it_out = aie::begin_restrict_vector<16>((bfloat16 *)output_vector);
+    auto it_in = aie::begin_restrict_vector<32>((bfloat16 *)input_vector);
+    auto it_out = aie::begin_restrict_vector<32>((bfloat16 *)output_vector);
 
     AIE_PREPARE_FOR_PIPELINING
     AIE_LOOP_MIN_ITERATION_COUNT(64)
-    for (int i = 0; i < vector_size; i += 16) {
-        // Load input vector
-        aie::vector<bfloat16, 16> input = *it_in++;
+    for (int i = 0; i < vector_size; i += 32) {
+        auto input = *it_in++;
 
-        // Compute tanh approximation
-        aie::vector<bfloat16, 16> tanh_x = getTanhBf16(input);
+        // LUT-based tanh: split to 16-wide halves
+        aie::vector<bfloat16, 16> tanh_lo = getTanhBf16(input.extract<16>(0));
+        aie::vector<bfloat16, 16> tanh_hi = getTanhBf16(input.extract<16>(1));
 
-        // Store output vector
-        *it_out++ = tanh_x;
+        *it_out++ = aie::concat(tanh_lo, tanh_hi);
     }
 
     event1();

--- a/aie_kernels/aie2p/gelu.cc
+++ b/aie_kernels/aie2p/gelu.cc
@@ -8,42 +8,44 @@
 
 using namespace aie;
 
-// One 16-lane GELU (tanh approximation): 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3))).
-static inline aie::vector<bfloat16, 16> gelu_tanh_approx_v16(aie::vector<bfloat16, 16> x)
+// GELU (tanh approximation): 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3))).
+// Uses MAC fusion and s*beta precompute to minimize the dependency chain:
+//   inner1 = s*x + s_beta*x*x^2  (single MAC, instead of mul+add+mul)
+//   result = mac(0.5x, tanh, 0.5x)  (single MAC, instead of add+mul+mul)
+static inline aie::vector<bfloat16, 32> gelu_tanh_approx(aie::vector<bfloat16, 32> x)
 {
     const bfloat16 k0_5 = 0.5f;
-    const bfloat16 k1 = 1.0f;
     const bfloat16 sqrt_2_over_pi = 0.79788456f; // sqrt(2/pi)
-    const bfloat16 kBeta = 0.044715f;
+    const bfloat16 s_beta = sqrt_2_over_pi * 0.044715f; // precomputed s*beta
 
-    auto v05 = aie::broadcast<bfloat16, 16>(k0_5);
-    auto v1 = aie::broadcast<bfloat16, 16>(k1);
-    auto vs2opi = aie::broadcast<bfloat16, 16>(sqrt_2_over_pi);
-    auto vBeta = aie::broadcast<bfloat16, 16>(kBeta);
+    auto v05 = aie::broadcast<bfloat16, 32>(k0_5);
+    auto vs2opi = aie::broadcast<bfloat16, 32>(sqrt_2_over_pi);
+    auto vsBeta = aie::broadcast<bfloat16, 32>(s_beta);
 
-    aie::vector<bfloat16, 16> x2 = aie::mul(x, x);
-    aie::vector<bfloat16, 16> x3 = aie::mul(x, x2);
-    aie::vector<bfloat16, 16> x3_beta = aie::mul(x3, vBeta);
-    aie::vector<bfloat16, 16> inner = aie::add(x, x3_beta);
-    auto inner1 = aie::mul(inner, vs2opi);
+    aie::vector<bfloat16, 32> x2 = aie::mul(x, x).to_vector<bfloat16>();
+    aie::vector<bfloat16, 32> sbeta_x = aie::mul(x, vsBeta).to_vector<bfloat16>();
+    auto sx = aie::mul(x, vs2opi);
+    auto half_x = aie::mul(x, v05);
+
+    auto inner1 = aie::mac(sx, sbeta_x, x2);
     auto tanh_out = aie::tanh<bfloat16>(inner1.to_vector<float>());
-    aie::vector<bfloat16, 16> one_plus_tanh = aie::add(tanh_out, v1);
-    aie::vector<bfloat16, 16> mul_v05 = aie::mul(v05, one_plus_tanh);
-    return aie::mul(x, mul_v05).to_vector<bfloat16>();
+
+    return aie::mac(half_x, tanh_out, half_x.to_vector<bfloat16>()).to_vector<bfloat16>();
 }
 
 // Out-of-place GELU: output_vector = gelu(input_vector). input and output must not alias.
 void gelu_tanh_approx_bf16(bfloat16 *restrict input_vector, bfloat16 *restrict output_vector, const int32_t vector_size)
 {
     event0();
-    auto it_in = aie::begin_restrict_vector<16>((bfloat16 *)input_vector);
-    auto it_out = aie::begin_restrict_vector<16>((bfloat16 *)output_vector);
+    auto it_in = aie::begin_restrict_vector<32>((bfloat16 *)input_vector);
+    auto it_out = aie::begin_restrict_vector<32>((bfloat16 *)output_vector);
 
-    AIE_PREPARE_FOR_PIPELINING
-    AIE_LOOP_MIN_ITERATION_COUNT(1)
-    for (int i = 0; i < vector_size; i += 16) {
-        *it_out++ = gelu_tanh_approx_v16(*it_in++);
-    }
+    // AIE_PREPARE_FOR_POSTPIPELINING is required: the pre-RA pipeliner finds no
+    // schedule for this body; the post-RA pipeliner achieves II=18, NS=2.
+    auto body = [&]() __attribute__((always_inline)) {
+        *it_out++ = gelu_tanh_approx(*it_in++);
+    };
+    VERSIONED_LOOP(2, (vector_size + 31) / 32, body, AIE_PREPARE_FOR_POSTPIPELINING);
     event1();
 }
 
@@ -51,13 +53,12 @@ void gelu_tanh_approx_bf16(bfloat16 *restrict input_vector, bfloat16 *restrict o
 static inline void gelu_tanh_approx_inplace_bf16(bfloat16 *restrict v, const int32_t vector_size)
 {
     event0();
-    auto it = aie::begin_restrict_vector<16>(v);
-    AIE_PREPARE_FOR_PIPELINING
-    AIE_LOOP_MIN_ITERATION_COUNT(1)
-    for (int i = 0; i < vector_size; i += 16) {
-        aie::vector<bfloat16, 16> x = *it;
-        *it++ = gelu_tanh_approx_v16(x);
-    }
+    auto it = aie::begin_restrict_vector<32>(v);
+    auto body = [&]() __attribute__((always_inline)) {
+        aie::vector<bfloat16, 32> x = *it;
+        *it++ = gelu_tanh_approx(x);
+    };
+    VERSIONED_LOOP(2, (vector_size + 31) / 32, body, AIE_PREPARE_FOR_POSTPIPELINING);
     event1();
 }
 

--- a/aie_kernels/aie2p/gelu.cc
+++ b/aie_kernels/aie2p/gelu.cc
@@ -15,7 +15,7 @@ using namespace aie;
 static inline aie::vector<bfloat16, 32> gelu_tanh_approx(aie::vector<bfloat16, 32> x)
 {
     const bfloat16 k0_5 = 0.5f;
-    const bfloat16 sqrt_2_over_pi = 0.79788456f; // sqrt(2/pi)
+    const bfloat16 sqrt_2_over_pi = 0.79788456f;        // sqrt(2/pi)
     const bfloat16 s_beta = sqrt_2_over_pi * 0.044715f; // precomputed s*beta
 
     auto v05 = aie::broadcast<bfloat16, 32>(k0_5);
@@ -42,7 +42,8 @@ void gelu_tanh_approx_bf16(bfloat16 *restrict input_vector, bfloat16 *restrict o
 
     // AIE_PREPARE_FOR_POSTPIPELINING is required: the pre-RA pipeliner finds no
     // schedule for this body; the post-RA pipeliner achieves II=18, NS=2.
-    auto body = [&]() __attribute__((always_inline)) {
+    auto body = [&]() __attribute__((always_inline))
+    {
         *it_out++ = gelu_tanh_approx(*it_in++);
     };
     VERSIONED_LOOP(2, (vector_size + 31) / 32, body, AIE_PREPARE_FOR_POSTPIPELINING);
@@ -54,7 +55,8 @@ static inline void gelu_tanh_approx_inplace_bf16(bfloat16 *restrict v, const int
 {
     event0();
     auto it = aie::begin_restrict_vector<32>(v);
-    auto body = [&]() __attribute__((always_inline)) {
+    auto body = [&]() __attribute__((always_inline))
+    {
         aie::vector<bfloat16, 32> x = *it;
         *it++ = gelu_tanh_approx(x);
     };

--- a/aie_kernels/aie2p/layer_norm.cc
+++ b/aie_kernels/aie2p/layer_norm.cc
@@ -103,6 +103,6 @@ extern "C" {
 void layer_norm(bfloat16 *input, bfloat16 *output, int32_t cols)
 {
     ::aie::set_rounding(aie::rounding_mode::conv_even);
-    layer_norm<bfloat16, 16>(input, output, cols);
+    layer_norm<bfloat16, 32>(input, output, cols);
 }
 }

--- a/aie_kernels/aie2p/rms_norm.cc
+++ b/aie_kernels/aie2p/rms_norm.cc
@@ -73,13 +73,13 @@ void rms_norm_bf16_vector(bfloat16 *input, bfloat16 *output, int32_t size, float
 {
     ::aie::set_rounding(aie::rounding_mode::conv_even); // round-to-nearest-even; do not inherit a floor rounding mode
                                                         // from a prior kernel
-    rms_norm_general<bfloat16, 16>(input, nullptr, output, size, epsilon);
+    rms_norm_general<bfloat16, 32>(input, nullptr, output, size, epsilon);
 }
 
 void weighted_rms_norm(bfloat16 *a_in, bfloat16 *b_in, bfloat16 *c_out, int32_t size, float epsilon)
 {
     ::aie::set_rounding(aie::rounding_mode::conv_even); // round-to-nearest-even; do not inherit a floor rounding mode
                                                         // from a prior kernel
-    rms_norm_general<bfloat16, 16>(a_in, b_in, c_out, size, epsilon);
+    rms_norm_general<bfloat16, 32>(a_in, b_in, c_out, size, epsilon);
 }
 }

--- a/aie_kernels/aie2p/sigmoid.cc
+++ b/aie_kernels/aie2p/sigmoid.cc
@@ -15,26 +15,27 @@ void sigmoid_tanh_approx_bf16(bfloat16 *restrict input_vector,
     event0();
 
     int num_elems = vector_size;
-    auto it_in = aie::begin_restrict_vector<16>((bfloat16 *)input_vector);
-    auto it_out = aie::begin_restrict_vector<16>((bfloat16 *)output_vector);
+    auto it_in = aie::begin_restrict_vector<32>((bfloat16 *)input_vector);
+    auto it_out = aie::begin_restrict_vector<32>((bfloat16 *)output_vector);
 
-    aie::vector<bfloat16, 16> input;
-    aie::vector<bfloat16, 16> output;
     aie::vector<bfloat16, 16> register_0_5 = aie::broadcast<bfloat16, 16>(0.5f);
-    aie::vector<bfloat16, 16> register_1 = aie::broadcast<bfloat16, 16>(1.0f);
+    aie::vector<bfloat16, 32> register_1 = aie::broadcast<bfloat16, 32>(1.0f);
+    aie::vector<bfloat16, 32> register_0_5_wide = aie::broadcast<bfloat16, 32>(0.5f);
     AIE_PREPARE_FOR_PIPELINING
     AIE_LOOP_MIN_ITERATION_COUNT(64)
-    for (int i = 0; i < num_elems; i += 16) {
-        // Load input vector
-        input = *it_in++;
+    for (int i = 0; i < num_elems; i += 32) {
+        auto input = *it_in++;
 
-        // Compute tanh approximation
-        auto half_x = aie::mul(input, register_0_5);
-        auto tanh_half_x = aie::tanh<bfloat16>(half_x.to_vector<float>());
-        auto tanh_half_x_approx = aie::add(tanh_half_x, register_1);
-        aie::vector<bfloat16, 16> sigmoid_approx = aie::mul(tanh_half_x_approx, register_0_5);
+        // tanh(x/2) split to two 16-wide halves
+        auto half_x_lo = aie::mul(input.extract<16>(0), register_0_5);
+        auto half_x_hi = aie::mul(input.extract<16>(1), register_0_5);
+        auto tanh_lo = aie::tanh<bfloat16>(half_x_lo.to_vector<float>());
+        auto tanh_hi = aie::tanh<bfloat16>(half_x_hi.to_vector<float>());
+        aie::vector<bfloat16, 32> tanh_half_x = aie::concat(tanh_lo, tanh_hi);
 
-        // Store output vector
+        auto one_plus = aie::add(tanh_half_x, register_1);
+        aie::vector<bfloat16, 32> sigmoid_approx = aie::mul(one_plus, register_0_5_wide);
+
         *it_out++ = sigmoid_approx;
     }
 

--- a/aie_kernels/aie2p/silu.cc
+++ b/aie_kernels/aie2p/silu.cc
@@ -13,28 +13,28 @@ void silu_tanh_approx_bf16(bfloat16 *restrict input_vector, bfloat16 *restrict o
     event0();
 
     int num_elems = vector_size;
-    auto it_in = aie::begin_restrict_vector<16>((bfloat16 *)input_vector);
-    auto it_out = aie::begin_restrict_vector<16>((bfloat16 *)output_vector);
+    auto it_in = aie::begin_restrict_vector<32>((bfloat16 *)input_vector);
+    auto it_out = aie::begin_restrict_vector<32>((bfloat16 *)output_vector);
 
-    aie::vector<bfloat16, 16> input;
-    aie::vector<bfloat16, 16> output;
     aie::vector<bfloat16, 16> register_0_5 = aie::broadcast<bfloat16, 16>(0.5f);
-    aie::vector<bfloat16, 16> register_1 = aie::broadcast<bfloat16, 16>(1.0f);
+    aie::vector<bfloat16, 32> register_1 = aie::broadcast<bfloat16, 32>(1.0f);
+    aie::vector<bfloat16, 32> register_0_5_wide = aie::broadcast<bfloat16, 32>(0.5f);
     AIE_PREPARE_FOR_PIPELINING
     AIE_LOOP_MIN_ITERATION_COUNT(64)
-    for (int i = 0; i < num_elems; i += 16) {
-        // Load input vector
-        input = *it_in++;
+    for (int i = 0; i < num_elems; i += 32) {
+        auto input = *it_in++;
 
-        // Compute tanh approximation
-        auto half_x = aie::mul(input, register_0_5);
-        auto tanh_half_x = aie::tanh<bfloat16>(half_x.to_vector<float>());
-        auto tanh_half_x_approx = aie::add(tanh_half_x, register_1);
-        aie::vector<bfloat16, 16> sigmoid_approx = aie::mul(tanh_half_x_approx, register_0_5);
-        // Compute output: x * tanh_approx
+        // tanh(x/2) split to two 16-wide halves
+        auto half_x_lo = aie::mul(input.extract<16>(0), register_0_5);
+        auto half_x_hi = aie::mul(input.extract<16>(1), register_0_5);
+        auto tanh_lo = aie::tanh<bfloat16>(half_x_lo.to_vector<float>());
+        auto tanh_hi = aie::tanh<bfloat16>(half_x_hi.to_vector<float>());
+        aie::vector<bfloat16, 32> tanh_half_x = aie::concat(tanh_lo, tanh_hi);
+
+        auto one_plus = aie::add(tanh_half_x, register_1);
+        aie::vector<bfloat16, 32> sigmoid_approx = aie::mul(one_plus, register_0_5_wide);
         auto mul_output = aie::mul(input, sigmoid_approx);
 
-        // Store output vector
         *it_out++ = mul_output.to_vector<bfloat16>();
     }
 

--- a/aie_kernels/aie2p/tanh.cc
+++ b/aie_kernels/aie2p/tanh.cc
@@ -13,24 +13,23 @@ void tanh_bf16_vectorized(bfloat16 *restrict input_vector, bfloat16 *restrict ou
     event0();
 
     int num_elems = vector_size;
-    auto it_in = aie::begin_restrict_vector<16>((bfloat16 *)input_vector);
-    auto it_out = aie::begin_restrict_vector<16>((bfloat16 *)output_vector);
+    auto it_in = aie::begin_restrict_vector<32>((bfloat16 *)input_vector);
+    auto it_out = aie::begin_restrict_vector<32>((bfloat16 *)output_vector);
 
-    aie::vector<bfloat16, 16> input;
-    aie::accum<accfloat, 16> acc;
-    aie::vector<bfloat16, 16> output;
     AIE_PREPARE_FOR_PIPELINING
     AIE_LOOP_MIN_ITERATION_COUNT(64)
-    for (int i = 0; i < num_elems; i += 16) {
-        // Load input vector
-        input = *it_in++;
+    for (int i = 0; i < num_elems; i += 32) {
+        auto input = *it_in++;
 
-        // Compute tanh
-        acc.from_vector(input, 0);
-        auto tanh_x = aie::tanh<bfloat16>(acc.to_vector<float>());
+        // vtanh operates on 16 float lanes; split to two halves
+        aie::accum<accfloat, 16> acc_lo;
+        aie::accum<accfloat, 16> acc_hi;
+        acc_lo.from_vector(input.extract<16>(0), 0);
+        acc_hi.from_vector(input.extract<16>(1), 0);
+        auto tanh_lo = aie::tanh<bfloat16>(acc_lo.to_vector<float>());
+        auto tanh_hi = aie::tanh<bfloat16>(acc_hi.to_vector<float>());
 
-        // Store output vector
-        *it_out++ = tanh_x;
+        *it_out++ = aie::concat(tanh_lo, tanh_hi);
     }
 
     event1();

--- a/aie_kernels/aie_kernel_utils.h
+++ b/aie_kernels/aie_kernel_utils.h
@@ -69,4 +69,26 @@
 #define AIE_LOOP_FLATTEN
 #endif
 
+// Runs `body` (a zero-arg lambda) `count` times. When count >= MinIters the loop is
+// eligible for software pipelining (extra pragma macros may be passed after `body`,
+// e.g. AIE_PREPARE_FOR_POSTPIPELINING); otherwise a plain no-unroll loop is emitted,
+// avoiding invalid pipeliner assumptions for tiny trip counts.
+#define VERSIONED_LOOP(MinIters, count, body, ...)                                                                     \
+    do {                                                                                                               \
+        if ((count) >= (MinIters)) {                                                                                   \
+            __VA_ARGS__                                                                                                \
+            AIE_LOOP_RANGE(MinIters, )                                                                                 \
+            for (int _vl_i = 0; _vl_i < (count); _vl_i++) {                                                            \
+                (body)();                                                                                              \
+            }                                                                                                          \
+        } else {                                                                                                       \
+            AIE_NO_PREPARE_FOR_PIPELINING                                                                              \
+            AIE_LOOP_RANGE(1, )                                                                                        \
+            AIE_LOOP_NO_UNROLL                                                                                         \
+            for (int _vl_i = 0; _vl_i < (count); _vl_i++) {                                                            \
+                (body)();                                                                                              \
+            }                                                                                                          \
+        }                                                                                                              \
+    } while (0)
+
 #endif

--- a/aie_kernels/generic/add.cc
+++ b/aie_kernels/generic/add.cc
@@ -21,7 +21,7 @@ template <typename T_in, typename T_out> void eltwise_add(T_in *a, T_in *b, T_ou
 template <typename T_in, typename T_out> void eltwise_vadd(T_in *a, T_in *b, T_out *c, int size)
 {
 
-    constexpr int vec_factor = 16;
+    constexpr int vec_factor = 32;
     event0();
     T_in *__restrict pA1 = a;
     T_in *__restrict pB1 = b;

--- a/aie_kernels/generic/mul.cc
+++ b/aie_kernels/generic/mul.cc
@@ -20,9 +20,9 @@ template <typename T_in, typename T_out> void eltwise_vmul(T_in *a, T_in *b, T_o
 {
 
     event0();
-    for (int i = 0; i < size; i += 16) {
-        auto A = aie::load_v<16>(a + i);
-        auto B = aie::load_v<16>(b + i);
+    for (int i = 0; i < size; i += 32) {
+        auto A = aie::load_v<32>(a + i);
+        auto B = aie::load_v<32>(b + i);
         auto C = aie::mul(A, B).template to_vector<T_out>();
         aie::store_v(c + i, C);
     }

--- a/aie_kernels/generic/rope.cc
+++ b/aie_kernels/generic/rope.cc
@@ -75,9 +75,9 @@ extern "C" {
 void rope(bfloat16 *input, bfloat16 *lut, bfloat16 *output, int32_t dims)
 {
 #if defined(TWO_HALVES)
-    rope_kernel_two_halves<bfloat16, 16>(input, lut, output, dims); // For the two-halves method used in HF transformers
+    rope_kernel_two_halves<bfloat16, 32>(input, lut, output, dims); // For the two-halves method used in HF transformers
 #elif defined(INTERLEAVED)
-    rope_kernel_interleaved<bfloat16, 16>(
+    rope_kernel_interleaved<bfloat16, 32>(
         input, lut, output, dims); // For the interleaved method used in the Llama paper
 #endif
 }


### PR DESCRIPTION
Per AM027 AIE-ML v2 Architecture Manual, full vector register is 512b. AIE2P target provides instruction to full 512b load (`vldb x, [p], #64`) or half-width load (`vldb wl, [p], #32`, wastes bandwidth), with optimal 32 bf16 vmull, vadd, max, etc.

Some operations like transcendentals vtanh and vexp2 provide only 16 floats instructions (no 32 bfloats). Moreover, on AIE2 there is is no no hardware `vtanh` instruction, which results in LUT-based implementation. On AIE2, a 32-element bf16 load requires two 256b load instructions (`vlda wl` + `vlda wh` or two sequential `vldb wl`). On AIE2P, the same load is a single 512b instruction (`vldb x`). The key interesting note here, is that despite needing two load instructions, AIE2 still benefits from v32 because the vector ALU and accumulator paths operate on 512b registers natively anyways, reducing insns/elem.

Switching to 32 bf16 vectors provides a consistent 1.3 - 1.5 speedup for gelu/sigmoid/silu/tanh/rope/dequant/layer_norm/rms_norm/mul/add on AIE2P. As for AIE2, it also should improve the performance (from the assembly reading, not checked on a real hardware).

For tanh and exp2 the strategy is as simple as:
1. Load 32 bf16 elements
2. Split: `vec.extract<16>(0)`, `vec.extract<16>(1)`
3. Apply tanh to each half (2 calls)
4. Merge: `aie::concat(lo, hi)` -> 32 bf16 elements
5. Continue with 32-wide bf16 operations

For llama the improvements are also there (few percent for TTFT); +12.5% for swiglu (2048x2048). Not a large improvement there, as these operations are not a bottleneck, but are still nice to have.

Other notes:
1. There was a minor issue in `aie2/relu.cc` increment by 16 while working with v32 vectors.
2. layer_norm.cc was affected by https://github.com/Xilinx/llvm-aie/issues/734, which was fixed recently, so now it works fine with 32-sized vectors

<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
