### PR TITLE
Update llvm-aie version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@
 --extra-index-url https://pypi.org/simple
 
 mlir_aie==0.0.1.2026033104+e4f35d6
-llvm-aie
+llvm-aie==21.0.0.2026050601+2c363ce
 
 black
 reuse


### PR DESCRIPTION
Updated llvm-aie version to 21.0.0.2026050601.

<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

Describe the intent of your PR here.

## Added
-

## Changed
- Version pin for llvm-aie wheel to : 21.0.0.2026050601+2c363ce

## Removed
-

## PR Merge Checklist

1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
