### PR TITLE
Temporarily disable ReLU test, revert llvm-aie version change, reformat CI output

### DIFF
--- a/.github/actions/commit_results/action.yaml
+++ b/.github/actions/commit_results/action.yaml
@@ -64,7 +64,7 @@ runs:
       continue-on-error: true  # This step will fail for PRs from forks because of permission issues; ignore
       shell: bash
       run: |
-        ./ci/scripts/aggregate_summary.py --results-root ../results -o ../results/readme.md
+        ./ci/scripts/pretty_aggregate.py --results-root ../results -o ../results/readme.md
         cd ../results
         git add ${{ inputs.dir }}/all.csv ${{ inputs.dir }}/latest.csv ${{ inputs.dir }}/readme.md ${{ inputs.dir }}/trends.md readme.md
         git config user.name "github-actions[bot]"

--- a/.github/actions/prereqs/action.yaml
+++ b/.github/actions/prereqs/action.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "Install IRONCLAD Prerequisites"
+name: "Install IRON Prerequisites"
 
 inputs:
   env_name:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -9,7 +9,7 @@
 #
 # This workflow collects artifacts from ALL completed CI workflows for the same
 # head SHA, arranges them into the {arch}/{suite}/ layout expected by
-# aggregate_summary.py, and posts (or updates) a single aggregated comment.
+# pretty_aggregate.py, and posts (or updates) a single aggregated comment.
 
 name: Comment on PR with Test Results
 
@@ -52,7 +52,7 @@ jobs:
             const headBranch = context.payload.workflow_run.head_branch;
             core.info(`Head SHA: ${headSha}, branch: ${headBranch}`);
 
-            // Mapping: artifact name -> directory layout for aggregate_summary.py
+            // Mapping: artifact name -> directory layout for pretty_aggregate.py
             const ARTIFACT_MAP = {
               'results-phoenix-small':    'phoenix/small',
               'results-phoenix-examples': 'phoenix/examples',
@@ -155,7 +155,7 @@ jobs:
       - name: Generate aggregate summary
         if: steps.collect.outputs.skip != 'true'
         run: |
-          python ci/scripts/aggregate_summary.py \
+          python ci/scripts/pretty_aggregate.py \
             --results-root "${{ steps.collect.outputs.root }}" \
             -o "${{ steps.collect.outputs.root }}/summary.md"
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0
     <img src="https://img.shields.io/badge/code%20style-black-000000.svg" alt="Code style: black" /></a>
 
 <p align="center">
-   <img src="./images/XDNA2.png" alt="IRONCLAD Logo" style="max-width: 100%; height: auto;">
+   <img src="./images/XDNA2.png" alt="IRON Logo" style="max-width: 100%; height: auto;">
 </p>
 
 IRON is an open-source & close-to-metal Python API enabling fast and efficient execution on [AMD Ryzen™ AI NPUs](https://www.amd.com/en/products/processors/consumer/ryzen-ai.html). It relies on language bindings around the [MLIR-AIE](https://github.com/Xilinx/mlir-aie) dialect.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,7 +1,7 @@
 version = 1
 SPDX-PackageName = "iron"
 SPDX-PackageSupplier = "Advanced Micro Devices, Inc."
-SPDX-PackageDownloadLocation = "https://github.com/AARInternal/ironclad"
+SPDX-PackageDownloadLocation = "https://github.com/amd/IRON"
 
 [[annotations]]
 path = "iron/applications/llama_3.2_1b/prompt.txt"

--- a/ci/docker-based/iron-public-docker-ci-loop.service
+++ b/ci/docker-based/iron-public-docker-ci-loop.service
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [Unit]
-Description=Docker CI VM Loop for IRONCLAD
+Description=Docker CI VM Loop for IRON
 After=network.target
 
 [Service]

--- a/ci/scripts/pretty.py
+++ b/ci/scripts/pretty.py
@@ -6,6 +6,8 @@
 import argparse
 import csv
 
+from pretty_common import display_name, parse_checks, split_test_path, status_emoji
+
 parser = argparse.ArgumentParser(
     description="Turn CSV of CI results into markdown document"
 )
@@ -16,71 +18,65 @@ parser.add_argument("--commit", required=True)
 parser.add_argument("--metric", default=[], action="append")
 args = parser.parse_args()
 
-with open(args.csv, "r") as f:
-    reader = csv.DictReader(f)
-    rows = [row for row in reader]
-
-by_test = {}
 
 with open(args.csv, "r") as f:
     reader = csv.DictReader(f)
     rows = [row for row in reader]
 
-by_test = {}
 
+# Group rows by their test directory. Within each group, collect (display_name, row).
+groups = {}
 for row in rows:
-    test = row["Test"]
-    if test not in by_test:
-        by_test[test] = {}
-    for k in row:
-        if k not in by_test[test]:
-            by_test[test][k] = []
-        val = None
-        try:
-            val = float(row[k])
-        except ValueError:
-            val = row[k]
-        by_test[test][k].append(val)
+    test_path = row.get("Test Path", "") or ""
+    test_name = row.get("Test", "")
+    directory, func = split_test_path(test_path)
+    display = display_name(func, test_name, fallback=test_path or "?")
+    # Fallback group name when Test Path is missing.
+    if not directory:
+        directory = "(unknown)"
+    groups.setdefault(directory, []).append((display, row))
 
 
 def print_test(test_name, test):
-    passed, n_checks = 0, 0
-    if "Checks" in test:
-        passed, n_checks = map(int, test["Checks"][0].split("/"))
-
-    out = f"""
-        <tr>
-            <td>
-                {test_name}
-            </td>
-            <td>
-                {("✅" if passed == n_checks else "❌" if passed == 0 else "🟠")
-                 if "Checks" in test and test["Checks"] else "?"}
-                {passed}/{n_checks}
-            </td>{"".join(f"""
-            <td>
-                {f"{test[metric][0]:.2f}" if metric in test and isinstance(test[metric][0], float) else "n/a"}
-            </td>""" for metric in args.metric)}
-        </tr>"""
-    return out
+    passed, n_checks = parse_checks(test.get("Checks", ""))
+    status = status_emoji(passed, n_checks, partial=True)
+    metric_cells = "".join(
+        f"""<td>{f"{float(test[metric]):.2f}" if test.get(metric) not in (None, "", "n/a") else "n/a"}</td>"""
+        for metric in args.metric
+    )
+    return f"""
+        <tr><td>{test_name}</td><td>{status} {passed}/{n_checks}</td>{metric_cells}</tr>"""
 
 
-out = f"""
-# IRONCLAD
-
-Tested on `{args.date}` at commit `{args.commit}`.
+def render_group(directory, entries):
+    header = "".join(f"<td>{metric}</td>" for metric in args.metric)
+    body = "".join(print_test(display, row) for display, row in entries)
+    return f"""
+<details>
+<summary>{directory}</summary>
 
 <table>
     <thead>
-        <tr>
-            <td>Test</td>
-            <td>Checks</td>
-            {"".join(f"<td>{metric}</td>" for metric in args.metric)}
-        </tr>
+        <tr><td>Test</td><td>Checks</td>{header}</tr>
     </thead>
-    <tbody>{"".join(print_test(test, by_test[test]) for test in by_test)}
+    <tbody>{body}
     </tbody>
 </table>
+
+</details>
+"""
+
+
+sections = "".join(
+    render_group(directory, sorted(groups[directory], key=lambda x: x[0]))
+    for directory in sorted(groups.keys())
+)
+
+out = f"""
+# IRON
+
+Tested on `{args.date}` at commit `{args.commit}`.
+{sections}
 """
 
 with open(args.output, "w") as f:

--- a/ci/scripts/pretty_aggregate.py
+++ b/ci/scripts/pretty_aggregate.py
@@ -9,6 +9,8 @@ import argparse
 import csv
 import os
 
+from pretty_common import display_name, parse_checks, split_test_path, status_emoji
+
 parser = argparse.ArgumentParser(
     description="Aggregate CI results from all architecture subdirectories into a top-level readme.md"
 )
@@ -38,20 +40,22 @@ METRIC_PREFERENCE = [
 
 
 def read_latest_csv(path):
-    """Return a dict mapping test name -> {checks, passed, metrics}."""
+    """Return a dict mapping (directory, display_name) -> {checks, passed, metrics}."""
     if not os.path.exists(path):
         return {}
     with open(path, newline="") as f:
         reader = csv.DictReader(f)
         results = {}
         for row in reader:
-            test = row.get("Test", "")
-            checks = row.get("Checks", "")
-            try:
-                p, n = map(int, checks.split("/"))
-                passed = p == n
-            except (ValueError, AttributeError):
-                passed = None
+            test_path = row.get("Test Path", "") or ""
+            params = row.get("Test", "") or ""
+            directory, func = split_test_path(test_path)
+            if not directory:
+                directory = "(unknown)"
+            display = display_name(func, params, fallback=test_path or "?")
+
+            p, n = parse_checks(row.get("Checks", ""))
+            passed = (p == n) if n > 0 else None
 
             metrics = {}
             for m in METRIC_PREFERENCE:
@@ -59,16 +63,14 @@ def read_latest_csv(path):
                 if val:
                     metrics[m] = val
 
-            results[test] = {"passed": passed, "metrics": metrics}
+            results[(directory, display)] = {"passed": passed, "metrics": metrics}
         return results
 
 
 def status_str(entry):
-    if entry is None:
+    if entry is None or entry["passed"] is None:
         return "-"
-    if entry["passed"] is None:
-        return "-"
-    return "pass" if entry["passed"] else "**FAIL**"
+    return "✅" if entry["passed"] else "❌"
 
 
 def metric_str(entry):
@@ -86,7 +88,7 @@ def metric_str(entry):
 
 
 def metric_label(arch_results):
-    """Pick the metric column name present in most entries."""
+    """Pick the first metric column name present in any entry."""
     for m in METRIC_PREFERENCE:
         for entry in arch_results.values():
             if entry["metrics"].get(m):
@@ -102,33 +104,40 @@ for suite in SUITES:
         csv_path = os.path.join(args.results_root, arch, suite, "latest.csv")
         arch_results[arch] = read_latest_csv(csv_path)
 
-    all_tests = sorted(set(arch_results["krackan"]) | set(arch_results["phoenix"]))
+    all_keys = set(arch_results["krackan"]) | set(arch_results["phoenix"])
 
     # Skip suite entirely when there is no data
-    if not all_tests:
+    if not all_keys:
         continue
+
+    # Group keys by directory
+    by_dir = {}
+    for directory, display in all_keys:
+        by_dir.setdefault(directory, []).append(display)
 
     # Determine metric labels per arch
     k_metric = metric_label(arch_results["krackan"])
     p_metric = metric_label(arch_results["phoenix"])
-
-    # Build header with merged arch columns
     k_metric_hdr = f" {k_metric}" if k_metric else ""
     p_metric_hdr = f" {p_metric}" if p_metric else ""
 
-    lines += [
-        f"## {suite.capitalize()}",
-        "",
-        f"| Test | Krackan Status | Krackan{k_metric_hdr} | Phoenix Status | Phoenix{p_metric_hdr} |",
-        "|---|---|---|---|---|",
-    ]
-    for test in all_tests:
-        k = arch_results["krackan"].get(test)
-        p = arch_results["phoenix"].get(test)
-        lines.append(
-            f"| {test} | {status_str(k)} | {metric_str(k)} | {status_str(p)} | {metric_str(p)} |"
-        )
-    lines.append("")
+    lines += [f"## {suite.capitalize()}", ""]
+
+    for directory in sorted(by_dir.keys()):
+        lines += [
+            "<details>",
+            f"<summary>{directory}</summary>",
+            "",
+            f"| Test | Krackan Status | Krackan{k_metric_hdr} | Phoenix Status | Phoenix{p_metric_hdr} |",
+            "|---|---|---|---|---|",
+        ]
+        for display in sorted(by_dir[directory]):
+            k = arch_results["krackan"].get((directory, display))
+            p = arch_results["phoenix"].get((directory, display))
+            lines.append(
+                f"| {display} | {status_str(k)} | {metric_str(k)} | {status_str(p)} | {metric_str(p)} |"
+            )
+        lines += ["", "</details>", ""]
 
 output_path = args.output
 with open(output_path, "w") as f:

--- a/ci/scripts/pretty_common.py
+++ b/ci/scripts/pretty_common.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for the pretty_* CI report scripts."""
+
+import os
+from typing import Tuple
+
+
+def split_test_path(test_path: str) -> Tuple[str, str]:
+    """Split a 'Test Path' value of the form 'dir/.../test.py::funcname'
+    into (directory, funcname). Returns ('', '') style fallbacks if parts
+    are missing.
+    """
+    if "::" in test_path:
+        file_part, func = test_path.split("::", 1)
+    else:
+        file_part, func = test_path, ""
+    directory = os.path.dirname(file_part).rstrip("/")
+    return directory, func
+
+
+def display_name(func: str, params: str, fallback: str = "?") -> str:
+    """Build a 'funcname[params]' display string with sensible fallbacks."""
+    if func and params:
+        return f"{func}[{params}]"
+    if func:
+        return func
+    return params or fallback
+
+
+def parse_checks(checks: str) -> Tuple[int, int]:
+    """Parse a 'p/n' checks string into (passed, total). Returns (0, 0) on
+    malformed input.
+    """
+    if not checks:
+        return 0, 0
+    try:
+        p, n = map(int, checks.split("/"))
+        return p, n
+    except (ValueError, AttributeError):
+        return 0, 0
+
+
+def status_emoji(passed: int, total: int, partial: bool = True) -> str:
+    """Render pass/fail status as an emoji.
+
+    - ✅ when all checks pass
+    - ❌ when none pass
+    - 🟠 when some pass (only if `partial` is True; otherwise ❌)
+    - '?' when there are no checks at all
+    """
+    if total == 0:
+        return "?"
+    if passed == total:
+        return "✅"
+    if passed == 0:
+        return "❌"
+    return "🟠" if partial else "❌"

--- a/ci/scripts/pretty_trends.py
+++ b/ci/scripts/pretty_trends.py
@@ -6,7 +6,9 @@
 import argparse
 import csv
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
+
+from pretty_common import display_name, split_test_path
 
 
 def parse_args():
@@ -31,6 +33,11 @@ def parse_args():
     )
     p.add_argument(
         "--test-column", default="Test", help="Test column name (default: Test)"
+    )
+    p.add_argument(
+        "--test-path-column",
+        default="Test Path",
+        help="Test path column name (default: 'Test Path')",
     )
     p.add_argument(
         "--round",
@@ -102,7 +109,7 @@ def build_table_for_test(
 
     header_cols = "".join(f"<th>{m}</th>" for m in metrics)
     out = []
-    out.append(f"\n## {test_name}\n")
+    out.append(f"\n### {test_name}\n")
     if len(metrics) == 0:
         out.append("_No metrics available._\n")
         return "\n".join(out)
@@ -156,41 +163,52 @@ def main():
         field_order = reader.fieldnames or []
 
     test_col = args.test_column
+    test_path_col = args.test_path_column
     commit_col = args.commit_column
     date_col = args.date_column
 
-    # Group by test
-    by_test: Dict[str, List[Dict[str, str]]] = {}
+    # Group rows by (directory, display_name). The display_name is
+    # 'funcname[params]' derived from Test Path + Test.
+    by_dir: Dict[str, Dict[str, List[Dict[str, str]]]] = {}
     for row in rows:
-        test = row.get(test_col, "").strip() or "UNNAMED_TEST"
-        by_test.setdefault(test, []).append(row)
+        test_path = (row.get(test_path_col) or "").strip()
+        params = (row.get(test_col) or "").strip()
+        directory, func = split_test_path(test_path)
+        if not directory:
+            directory = "(unknown)"
+        display = display_name(func, params, fallback=test_path or "UNNAMED_TEST")
+        by_dir.setdefault(directory, {}).setdefault(display, []).append(row)
 
     # Build output
     out_parts = []
-    out_parts.append("# IRONCLAD Trends\n")
+    out_parts.append("# IRON Trends\n")
 
-    exclude_cols = {test_col, commit_col, date_col, "Checks"}
+    exclude_cols = {test_col, test_path_col, commit_col, date_col, "Checks"}
 
-    for test in sorted(by_test.keys()):
-        test_rows = by_test[test]
-        metrics = [
-            k
-            for k in field_order
-            if k not in exclude_cols
-            and any(try_parse_float(r.get(k)) is not None for r in test_rows)
-        ]
-        metrics.sort()
-        section = build_table_for_test(
-            test_name=test,
-            rows=test_rows,
-            metrics=metrics,
-            date_col=date_col,
-            commit_col=commit_col,
-            ndigits=args.ndigits,
-            threshold=args.threshold,
-            date_fmt=args.date_fmt,
-        )
-        out_parts.append(section)
+    for directory in sorted(by_dir.keys()):
+        out_parts.append(f"\n<details>\n<summary>{directory}</summary>\n")
+        tests_in_dir = by_dir[directory]
+        for test in sorted(tests_in_dir.keys()):
+            test_rows = tests_in_dir[test]
+            metrics = [
+                k
+                for k in field_order
+                if k not in exclude_cols
+                and any(try_parse_float(r.get(k)) is not None for r in test_rows)
+            ]
+            metrics.sort()
+            section = build_table_for_test(
+                test_name=test,
+                rows=test_rows,
+                metrics=metrics,
+                date_col=date_col,
+                commit_col=commit_col,
+                ndigits=args.ndigits,
+                threshold=args.threshold,
+                date_fmt=args.date_fmt,
+            )
+            out_parts.append(section)
+        out_parts.append("\n</details>\n")
 
     with open(args.output, "w", newline="") as f:
         f.write("\n".join(out_parts))

--- a/conftest.py
+++ b/conftest.py
@@ -60,24 +60,26 @@ class CSVReporter:
         self.date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         self.test_metrics = {}  # test_name -> {metric_name -> [values]}
 
-    def add_result(self, test_name, passed, captured_output, metric_patterns):
-        self.test_metrics.setdefault(test_name, {}).setdefault("passed", []).append(
-            passed
-        )
+    def add_result(
+        self, test_path, test_name, passed, captured_output, metric_patterns
+    ):
+        key = (test_path, test_name)
+        self.test_metrics.setdefault(key, {}).setdefault("passed", []).append(passed)
 
         for metric_name, pattern in metric_patterns.items():
             match = re.search(pattern, captured_output)
             if not match:
                 continue
             value = float(match.group("value"))
-            self.test_metrics[test_name].setdefault(metric_name, []).append(value)
+            self.test_metrics[key].setdefault(metric_name, []).append(value)
 
     def finalize_results(self):
         """Compute statistics for all collected metrics"""
-        for test_name, data in self.test_metrics.items():
+        for (test_path, test_name), data in self.test_metrics.items():
             row = {
                 "Commit": self.commit,
                 "Date": self.date,
+                "Test Path": test_path,
                 "Test": test_name,
                 "Checks": f"{sum(data['passed'])}/{len(data['passed'])}",
             }
@@ -95,7 +97,7 @@ class CSVReporter:
             self.results.append(row)
 
     def write_csv(self):
-        self.results.sort(key=lambda x: (x["Test"], x["Date"]))
+        self.results.sort(key=lambda x: (x.get("Test Path", ""), x["Test"], x["Date"]))
 
         cols = {}
         for row in self.results:
@@ -128,13 +130,16 @@ def pytest_runtest_makereport(item, call):
         if csv_reporter:
             # The pytest nodeid looks like this:
             # iron/operators/dequant/test.py::test_dequant[iter0-dequant_8_cols_2_channels_2048_tile_128]
-            # Extract only the stem out of that.
+            # Split into:
+            #   test_path: iron/operators/dequant/test.py::test_dequant
+            #   test_name: just the parametrize id (without iter prefix)
             nodeid_components = re.match(
-                r"^(.+?)::(.+?)\[(iter\d+-)?(.+?)\]$", item.nodeid
+                r"^(.+?::[^\[]+)\[(iter\d+-)?(.+?)\]$", item.nodeid
             )
             if not nodeid_components:
                 raise RuntimeError(f"Unexpected test nodeid format: {item.nodeid}")
-            test_name = nodeid_components.group(4)
+            test_path = nodeid_components.group(1)
+            test_name = nodeid_components.group(3)
 
             passed = report.outcome == "passed"
             captured = report.capstdout
@@ -145,7 +150,9 @@ def pytest_runtest_makereport(item, call):
                 metric_patterns = marker.kwargs
                 break
 
-            csv_reporter.add_result(test_name, passed, captured, metric_patterns)
+            csv_reporter.add_result(
+                test_path, test_name, passed, captured, metric_patterns
+            )
 
 
 def pytest_configure(config):

--- a/iron/applications/llama_3.2_1b/llama_npu.py
+++ b/iron/applications/llama_3.2_1b/llama_npu.py
@@ -1245,7 +1245,7 @@ def llama_forward_pass_decode(config, state):
     assert seq_len == 1
     assert state.num_preceding_tokens < max_seq_len
 
-    # patch_fused_decode_operator(aie_ops.decode, config, state.num_preceding_tokens)
+    patch_fused_decode_operator(aie_ops.decode, config, state.num_preceding_tokens)
 
     # Prefill RoPE angle look-up tables
     angles_slice = config.angles[
@@ -1293,7 +1293,6 @@ def llama_forward_pass(config, state):
                 :
             ] = (aie_buffers.values_cache[layer_idx].to_torch().flatten())
         aie_ops.decode.fused.scratch_buffer.to("cpu")
-        patch_fused_decode_operator(aie_ops.decode, config, 1024)
         return ret
     else:
         ret = llama_forward_pass_decode(config, state)

--- a/iron/applications/llama_3.2_1b/llama_npu.py
+++ b/iron/applications/llama_3.2_1b/llama_npu.py
@@ -1245,7 +1245,7 @@ def llama_forward_pass_decode(config, state):
     assert seq_len == 1
     assert state.num_preceding_tokens < max_seq_len
 
-    #patch_fused_decode_operator(aie_ops.decode, config, state.num_preceding_tokens)
+    # patch_fused_decode_operator(aie_ops.decode, config, state.num_preceding_tokens)
 
     # Prefill RoPE angle look-up tables
     angles_slice = config.angles[

--- a/iron/applications/llama_3.2_1b/llama_npu.py
+++ b/iron/applications/llama_3.2_1b/llama_npu.py
@@ -1245,7 +1245,7 @@ def llama_forward_pass_decode(config, state):
     assert seq_len == 1
     assert state.num_preceding_tokens < max_seq_len
 
-    patch_fused_decode_operator(aie_ops.decode, config, state.num_preceding_tokens)
+    #patch_fused_decode_operator(aie_ops.decode, config, state.num_preceding_tokens)
 
     # Prefill RoPE angle look-up tables
     angles_slice = config.angles[
@@ -1293,6 +1293,7 @@ def llama_forward_pass(config, state):
                 :
             ] = (aie_buffers.values_cache[layer_idx].to_torch().flatten())
         aie_ops.decode.fused.scratch_buffer.to("cpu")
+        patch_fused_decode_operator(aie_ops.decode, config, 1024)
         return ret
     else:
         ret = llama_forward_pass_decode(config, state)

--- a/iron/operators/gelu/test.py
+++ b/iron/operators/gelu/test.py
@@ -10,8 +10,17 @@ from iron.common.test_utils import run_test, make_channeled_unary_params
 
 
 def get_params():
+    def _marks(ext, ts):
+        marks = []
+        if ext:
+            marks.append(pytest.mark.extensive)
+        # TODO: temporary - disable tile_size=8192 for GeLU, issue #113
+        if ts == 8192:
+            marks.append(pytest.mark.skip(reason="temporary: tile_size=8192 disabled for GeLU, see issue #113"))
+        return marks
+
     return [
-        pytest.param(il, nac, nc, ts, marks=[] if not ext else [pytest.mark.extensive])
+        pytest.param(il, nac, nc, ts, marks=_marks(ext, ts))
         for il, nac, nc, ts, ext in make_channeled_unary_params(
             [1024, 2048, 4096, 8192], 8192, [1, 2]
         )

--- a/iron/operators/gelu/test.py
+++ b/iron/operators/gelu/test.py
@@ -16,7 +16,11 @@ def get_params():
             marks.append(pytest.mark.extensive)
         # TODO: temporary - disable tile_size=8192 for GeLU, issue #113
         if ts == 8192:
-            marks.append(pytest.mark.skip(reason="temporary: tile_size=8192 disabled for GeLU, see issue #113"))
+            marks.append(
+                pytest.mark.skip(
+                    reason="temporary: tile_size=8192 disabled for GeLU, see issue #113"
+                )
+            )
         return marks
 
     return [

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@
 --extra-index-url https://pypi.org/simple
 
 mlir_aie==0.0.1.2026033104+e4f35d6
-llvm-aie==21.0.0.2026050601+2c363ce
+llvm-aie
 
 black
 reuse

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@
 --extra-index-url https://pypi.org/simple
 
 mlir_aie==0.0.1.2026033104+e4f35d6
-llvm-aie
+llvm-aie==21.0.0.2026051101+adc9df1a
 
 black
 reuse


### PR DESCRIPTION
The CI was down for a while. Now that it ran again it revealed the following issues which this PR fixes:

- GeLU extensive test for tile size 8192 was failing. Fix will be in [MLIR-AIE PR 3045](https://github.com/Xilinx/mlir-aie/pull/3045) -- until then, disable the test (tracking with issue #113).
- llvm-aie version cannot be found. Revert to previous peano.
- PR #88 made it so that all tests are only named by their parametrization (e.g. M_8192_K_8192...) so it becomes unclear what the actual tested operator is (e.g. GeLU). Include operator names.
- Reformat CI summaries a bit more pretty-ly.