### PR TITLE
gemm: honor func_prefix for kernel object and symbols (enables fusion)

### DIFF
--- a/iron/operators/gemm/design.py
+++ b/iron/operators/gemm/design.py
@@ -280,7 +280,11 @@ def my_matmul(
 
     # AIE Core Function declarations
     scalar_suffix = "_scalar" if use_scalar else ""
-    gemm_object = kernel_object or f"{func_prefix}gemm_{m}x{k}x{n}.o"
+    gemm_object = (
+        f"{func_prefix}{kernel_object}"
+        if kernel_object
+        else f"{func_prefix}gemm_{m}x{k}x{n}.o"
+    )
     if use_larger_internal_buffer:
         # Fix fifo depth for C objfifo to 1 since 1 buffer will be used for accumulation
         # and another for transfer to L2
@@ -289,17 +293,17 @@ def my_matmul(
         C_l1_ty_internal = np.ndarray[(m, n), np.dtype[dtype_out_internal]]
         # A kernel to convert from the internal f32 accumulation to bf16 for transfer to L2 is needed
         convert_copy_kernel = Kernel(
-            f"convert_copy_f32_to_bf16",
-            "convert_copy.o",
+            f"{func_prefix}convert_copy_f32_to_bf16",
+            f"{func_prefix}convert_copy.o",
             [C_l1_ty_internal, C_l1_ty, np.int32],
         )
         # Fix the kernels to use f32 outputs
         zero_kernel = Kernel(
-            f"zero{scalar_suffix}_f32",
+            f"{func_prefix}zero{scalar_suffix}_f32",
             gemm_object,
             [C_l1_ty_internal],
         )
-        matmul_func_name = f"matmul{scalar_suffix}_{dtype_in_str}_f32"
+        matmul_func_name = f"{func_prefix}matmul{scalar_suffix}_{dtype_in_str}_f32"
         matmul_kernel = Kernel(
             matmul_func_name,
             gemm_object,
@@ -310,11 +314,13 @@ def my_matmul(
         # we only need the zero and matmul kernels
         fifo_depth_out = fifo_depth
         zero_kernel = Kernel(
-            f"zero{scalar_suffix}_{dtype_out_str}",
+            f"{func_prefix}zero{scalar_suffix}_{dtype_out_str}",
             gemm_object,
             [C_l1_ty],
         )
-        matmul_func_name = f"matmul{scalar_suffix}_{dtype_in_str}_{dtype_out_str}"
+        matmul_func_name = (
+            f"{func_prefix}matmul{scalar_suffix}_{dtype_in_str}_{dtype_out_str}"
+        )
         matmul_kernel = Kernel(
             matmul_func_name,
             gemm_object,


### PR DESCRIPTION
GEMV, softmax, and binary_elementwise already apply `func_prefix` to both the kernel object filename and the kernel symbols, so `FusedMLIROperator` can place several of them in one design. GEMM only applied `func_prefix` to the fallback generated-object name, leaving the supplied `kernel_object` name and the `zero_`/`matmul_`/`convert_copy_` symbols unprefixed — so fusing any GEMM via `FusedMLIROperator` failed with object-copy and undefined-symbol errors. (The in-tree `llama_3.2_1b` example builds a `FusedMLIROperator`.)

**Changed**
- `my_matmul` now applies `func_prefix` to the gemm and `convert_copy` object filenames and to the `zero_`/`matmul_`/`convert_copy_` kernel symbols.

**Added / Removed**
- None.

No-op when `func_prefix=""` (the non-fused default), so existing callers are byte-identical. Exercised in our own batched decode, which fuses GEMM via `FusedMLIROperator`.
