### PR TITLE
update pinned peano commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@
 --extra-index-url https://pypi.org/simple
 
 mlir_aie==0.0.1.2026033104+e4f35d6
-llvm-aie==21.0.0.2026051101+adc9df1a
+llvm-aie==21.0.0.2026062201+7820460e
 
 black
 reuse


### PR DESCRIPTION
IRON CI is failing because the peano wheel we pinned moved from `nightly` to `nightly-20240501-20260527`. I guess they hit the space limitation on `nightly`. 

Alternative to this would be to add `nightly-20240501-20260527` as the source we pull peano from, but if this update passes the tests, I think it doesn't hurt to just update.