### PR TITLE
Use ScratchpadParameter feature in Llama

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__
 build/*
 **/_build/**
 **/build/**
+**/build_elf/**
 *.exe
 *.csv
 secret_github_token
@@ -20,3 +21,4 @@ id_ed25519.pub
 *.model
 .cline_storage
 *.egg-info
+**/*.prj/**

--- a/iron/applications/llama_3.2_1b/llama_npu.py
+++ b/iron/applications/llama_3.2_1b/llama_npu.py
@@ -25,12 +25,7 @@ sys.path.insert(0, str(repo_root))
 
 from iron.common.context import AIEContext
 from iron.common.utils import XRTSubBuffer
-from iron.common.sequence import (
-    OperatorSequence,
-    SequenceFullELFCallable,
-    load_elf,
-    patch_elf,
-)
+from iron.common.sequence import OperatorSequence
 from iron.operators import (
     RMSNorm,
     GEMM,
@@ -312,18 +307,17 @@ class AIELlamaOperators:
             context=elf_ctx,
         )
 
-        strided_copy_cache_magic = 0xDEADBEE0
         strided_copy_cache_op = StridedCopy(
             input_sizes=(config.n_kv_groups, config.head_dim),
             input_strides=(config.head_dim, 1),
             input_offset=0,
             output_sizes=(1, config.n_kv_groups, config.head_dim),
             output_strides=(0, prompt_len * config.head_dim, 1),
-            output_offset=7 * config.head_dim * 2,  # Will be patched at runtime
+            output_offset=0,  # base; runtime addend supplied via cache_offset parameter
             input_buffer_size=1 * config.n_kv_groups * config.head_dim,
             output_buffer_size=config.n_kv_groups * prompt_len * config.head_dim,
             num_aie_channels=1,
-            kwargs={"output_offset_patch_marker": strided_copy_cache_magic},
+            output_offset_parameter="cache_offset",
             context=elf_ctx,
         )
 
@@ -347,14 +341,13 @@ class AIELlamaOperators:
         )
 
         # Softmax operators for attention weights
-        softmax_magic = 0xBA5EBA11
         softmax_op = Softmax(
             rows=config.n_heads,
             cols=prompt_len,
             num_aie_columns=1,
             num_channels=1,
-            rtp_vector_size=prompt_len,  # Compile with max size
-            mask_patch_value=softmax_magic,  # Magic value for patching
+            rtp_vector_size=prompt_len,  # Compile with max size (used as fallback / sanity)
+            vector_size_parameter="softmax_vector_size",
             context=elf_ctx,
         )
 
@@ -587,62 +580,7 @@ class AIELlamaOperators:
             context=elf_ctx,
         ).compile()
 
-        # Operator patching
-
-        self.decode.fused_elf_data = load_elf(self.decode.fused_op)
-
-        def get_patch_locs(elf_data, magic):
-            magic = magic & 0xFFFFFFFF
-            return np.where(elf_data == magic)[0]
-
-        keys_patches = {}
-        values_patches = {}
-        for layer_idx in range(config.n_layers):
-            _, keys_cache_offs, _ = self.decode.fused_op.get_layout_for_buffer(
-                f"keys_cache_{layer_idx}"
-            )
-            _, values_cache_offs, _ = self.decode.fused_op.get_layout_for_buffer(
-                f"values_cache_{layer_idx}"
-            )
-            keys_patches.update(
-                {
-                    int(l): keys_cache_offs
-                    for l in get_patch_locs(
-                        self.decode.fused_elf_data,
-                        (keys_cache_offs + strided_copy_cache_magic * 2),
-                    )
-                }
-            )
-            values_patches.update(
-                {
-                    int(l): values_cache_offs
-                    for l in get_patch_locs(
-                        self.decode.fused_elf_data,
-                        (values_cache_offs + strided_copy_cache_magic * 2),
-                    )
-                }
-            )
-        no_offset_patches = {
-            int(l): 0
-            for l in get_patch_locs(
-                self.decode.fused_elf_data, (strided_copy_cache_magic * 2)
-            )
-        }
-        self.decode.fused_patch_locations = {
-            **keys_patches,
-            **values_patches,
-            **no_offset_patches,
-        }
-        assert len(self.decode.fused_patch_locations) == 4 * config.n_layers + 2
-
-        self.decode.softmax_patch_offsets = get_patch_locs(
-            self.decode.fused_elf_data, softmax_magic
-        )
-        assert len(self.decode.softmax_patch_offsets) == config.n_layers + 1
-
-        self.decode.fused = SequenceFullELFCallable(
-            self.decode.fused_op, elf_data=self.decode.fused_elf_data
-        )
+        self.decode.fused = self.decode.fused_op.get_callable()
 
         # Operator static buffers (weights, LUTs)
 
@@ -1222,30 +1160,21 @@ def llama_forward_pass_prefill(config, state):
 # ##########################################################################
 
 
-def patch_fused_decode_operator(ops, config, num_preceding_tokens):
-    context_len = num_preceding_tokens + 1
-
-    # Patch fused operator for strided copy cache offset
-    output_offset = num_preceding_tokens * config.head_dim
-    offset_val = output_offset * 2  # Multiply by 2 for bfloat16 byte offset
-    strided_copy_patches = {
-        i: (base + offset_val, 0xFFFFFFFF)
-        for i, base in ops.fused_patch_locations.items()
-    }
-    softmax_patches = {i: (context_len, 0xFFFFFFFF) for i in ops.softmax_patch_offsets}
-    patches = {**strided_copy_patches, **softmax_patches}
-    patched_elf_data = ops.fused_elf_data.copy()
-    patch_elf(patched_elf_data, patches)
-
-    ops.fused.reload_elf(patched_elf_data)
-
-
 def llama_forward_pass_decode(config, state):
     batch, seq_len = state.token_ids.shape
     assert seq_len == 1
     assert state.num_preceding_tokens < max_seq_len
 
-    patch_fused_decode_operator(aie_ops.decode, config, state.num_preceding_tokens)
+    context_len = state.num_preceding_tokens + 1
+    cache_offset = state.num_preceding_tokens * config.head_dim
+    state.softmax_vector_size_cum = (
+        getattr(state, "softmax_vector_size_cum", 0) + context_len
+    )
+
+    params = aie_ops.decode.fused.params
+    params.write("cache_offset", np.int32(cache_offset))
+    params.write("softmax_vector_size", np.int32(state.softmax_vector_size_cum))
+    params.sync()
 
     # Prefill RoPE angle look-up tables
     angles_slice = config.angles[

--- a/iron/common/base.py
+++ b/iron/common/base.py
@@ -25,7 +25,6 @@ from .compilation import (
     KernelObjectArtifact,
     KernelArchiveArtifact,
     SourceArtifact,
-    PythonGeneratedMLIRArtifact,
 )
 
 

--- a/iron/common/compilation/__init__.py
+++ b/iron/common/compilation/__init__.py
@@ -9,6 +9,7 @@ from .base import (
     CompilationArtifactGraph,
     CompilationArtifact,
     SourceArtifact,
+    MLIRArtifact,
     FullElfArtifact,
     XclbinArtifact,
     InstsBinArtifact,
@@ -27,6 +28,6 @@ from .base import (
     ArchiveCompilationRule,
 )
 from .sequence import (
-    SequenceMLIRSource,
+    SequenceMLIRArtifact,
     FusePythonGeneratedMLIRCompilationRule,
 )

--- a/iron/common/compilation/base.py
+++ b/iron/common/compilation/base.py
@@ -286,21 +286,23 @@ class SourceArtifact(CompilationArtifact):
     pass
 
 
+class MLIRArtifact(CompilationArtifact):
+    """Base class for artifacts whose file is an MLIR (.mlir) module usable as aiecc input.
+
+    ``_MLIRInputMixin.mlir_input`` locates the MLIR source of a downstream
+    target (elf/xclbin/insts.bin) by looking for a dependency of this type.
+    Using a shared base class (rather than name-checking) lets other modules
+    such as ``compilation/sequence.py`` opt in without creating an import cycle.
+    """
+
+
 class _MLIRInputMixin:
     """Mixin providing a mlir_input property that finds the MLIR source in dependencies."""
 
     @property
     def mlir_input(self):
-        # Accept any MLIR-source-style artifact in dependencies. We name-check
-        # ``SequenceMLIRSource`` to avoid an import cycle with
-        # ``compilation/sequence.py`` (which itself imports from this module).
         result = next(
-            (
-                d
-                for d in self.dependencies
-                if isinstance(d, (SourceArtifact, PythonGeneratedMLIRArtifact))
-                or type(d).__name__ == "SequenceMLIRSource"
-            ),
+            (d for d in self.dependencies if isinstance(d, MLIRArtifact)),
             None,
         )
         if result is None:
@@ -375,7 +377,7 @@ class KernelArchiveArtifact(CompilationArtifact):
     pass
 
 
-class PythonGeneratedMLIRArtifact(CompilationArtifact):
+class PythonGeneratedMLIRArtifact(MLIRArtifact):
     def __init__(
         self,
         filename: str,
@@ -471,11 +473,9 @@ class GenerateMLIRFromPythonCompilationRule(CompilationRule):
         commands = []
         worklist = graph.get_worklist(PythonGeneratedMLIRArtifact)
         for artifact in worklist:
-            new_artifact = SourceArtifact(artifact.filename)
-            callback = partial(self.generate_mlir, new_artifact, artifact.generator)
+            callback = partial(self.generate_mlir, artifact, artifact.generator)
             commands.append(PythonCallbackCompilationCommand(callback))
-            new_artifact.available = True
-            graph.replace(artifact, new_artifact)
+            artifact.available = True
         return commands
 
     @staticmethod

--- a/iron/common/compilation/base.py
+++ b/iron/common/compilation/base.py
@@ -291,11 +291,15 @@ class _MLIRInputMixin:
 
     @property
     def mlir_input(self):
+        # Accept any MLIR-source-style artifact in dependencies. We name-check
+        # ``SequenceMLIRSource`` to avoid an import cycle with
+        # ``compilation/sequence.py`` (which itself imports from this module).
         result = next(
             (
                 d
                 for d in self.dependencies
                 if isinstance(d, (SourceArtifact, PythonGeneratedMLIRArtifact))
+                or type(d).__name__ == "SequenceMLIRSource"
             ),
             None,
         )

--- a/iron/common/compilation/sequence.py
+++ b/iron/common/compilation/sequence.py
@@ -95,15 +95,29 @@ def fuse_mlir(artifact: SequenceMLIRSource) -> None:
 
     input_buffer_size, output_buffer_size, scratch_buffer_size = artifact.buffer_sizes
 
-    # Extract device operations from each operator's MLIR artifact
+    # Extract device operations and module-level parameter decls from each
+    # operator's MLIR artifact.  Note: in the current MLIR-AIE pipeline,
+    # ``aiex.scratchpad_parameter`` ops are emitted at *module* scope (above the
+    # ``aie.device``), because the scratchpad is a single hardware resource
+    # shared across all PDIs in a runlist and the verifier on
+    # ``aiex.read_scratchpad_parameter`` requires the decl to be visible at module
+    # scope.  We collect those module-level decls per-operator so we can
+    # re-declare them once at the top of the fused module.
     device_mlir_strings = {}
+    operator_param_decls: dict[str, dict[str, ir.Type]] = {}
     device_ty = None
     sequence_arg_types = {}
     for op_name, mlir_artifact in artifact.operator_mlir_map.items():
         mlir_module = get_child_mlir_module(mlir_artifact)
-        device_ops = [
-            op for op in mlir_module.body.operations if isinstance(op, aie.DeviceOp)
-        ]
+        device_ops = []
+        params_here: dict[str, ir.Type] = {}
+        for op in mlir_module.body.operations:
+            if isinstance(op, aie.DeviceOp):
+                device_ops.append(op)
+            elif op.operation.name == "aiex.scratchpad_parameter":
+                sym_name = ir.StringAttr(op.operation.attributes["sym_name"]).value
+                param_type = ir.TypeAttr(op.operation.attributes["type"]).value
+                params_here[sym_name] = param_type
         if len(device_ops) != 1:
             raise ValueError(
                 f"Expected exactly one device operation in MLIR artifact for operator '{op_name}', "
@@ -113,14 +127,47 @@ def fuse_mlir(artifact: SequenceMLIRSource) -> None:
         if device_ty is None:
             device_ty = device_op.device
         device_mlir_strings[op_name] = str(device_op)
+        operator_param_decls[op_name] = params_here
         sequence_arg_types[op_name] = extract_runtime_sequence_arg_types(device_op)
+
+    # Deduplicate parameter decls across operators (same name must have the
+    # same type; otherwise indices would collide in the global state table).
+    hoisted_params: dict[str, ir.Type] = {}
+    for op_name, params_here in operator_param_decls.items():
+        for sym_name, param_type in params_here.items():
+            existing = hoisted_params.get(sym_name)
+            if existing is not None and str(existing) != str(param_type):
+                raise ValueError(
+                    f"ScratchpadParameter '{sym_name}' is declared with conflicting "
+                    f"types across operators: {existing} vs {param_type}"
+                )
+            hoisted_params[sym_name] = param_type
 
     # Build fused MLIR module
     with mlir_mod_ctx() as ctx:
 
-        # Concatenate aie.device ops
+        # Emit hoisted parameters first.
+        with ir.InsertionPoint.at_block_begin(ctx.module.body):
+            for sym_name, param_type in hoisted_params.items():
+                aiex.scratchpad_parameter(sym_name, param_type)
+
+        # Concatenate aie.device ops.
+        params_preamble = "\n".join(
+            f"  aiex.scratchpad_parameter @{name} : {param_type}"
+            for name, param_type in hoisted_params.items()
+        )
         for op_name, device_str in device_mlir_strings.items():
-            dev_op = aie.DeviceOp.parse(device_str)
+            wrapped = f"module {{\n{params_preamble}\n{device_str}\n}}"
+            wrapper_module = ir.Module.parse(wrapped)
+            # Find the (sole) DeviceOp in the wrapper module.
+            dev_op = None
+            for op in wrapper_module.body.operations:
+                if isinstance(op, aie.DeviceOp):
+                    dev_op = op
+                    break
+            assert (
+                dev_op is not None
+            ), f"DeviceOp missing after re-parse for operator '{op_name}'"
             dev_op.sym_name = ir.StringAttr.get(op_name)
             ctx.module.body.append(dev_op)
 

--- a/iron/common/compilation/sequence.py
+++ b/iron/common/compilation/sequence.py
@@ -19,20 +19,19 @@ import ml_dtypes
 from typing import Any
 
 from . import (
-    CompilationArtifact,
     CompilationArtifactGraph,
     CompilationRule,
     CompilationCommand,
     PythonCallbackCompilationCommand,
-    SourceArtifact,
     PythonGeneratedMLIRArtifact,
+    MLIRArtifact,
 )
 
 # Compilation Artifacts
 # ##########################################################################
 
 
-class SequenceMLIRSource(CompilationArtifact):
+class SequenceMLIRArtifact(MLIRArtifact):
     def __init__(
         self,
         filename: str,
@@ -90,7 +89,7 @@ def get_child_mlir_module(mlir_artifact: PythonGeneratedMLIRArtifact) -> Any:
     return callback_function(*gen.args, **gen.kwargs)
 
 
-def fuse_mlir(artifact: SequenceMLIRSource) -> None:
+def fuse_mlir(artifact: SequenceMLIRArtifact) -> None:
     """Fuse multiple MLIR modules by inlining their device operations and adding a new main device and runtime sequence that call into sequence of operations based on a runlist."""
 
     input_buffer_size, output_buffer_size, scratch_buffer_size = artifact.buffer_sizes
@@ -288,15 +287,13 @@ class FusePythonGeneratedMLIRCompilationRule(CompilationRule):
     """Compilation rule that fuses multiple MLIR modules into one."""
 
     def matches(self, graph: CompilationArtifactGraph) -> bool:
-        return any(graph.get_worklist(SequenceMLIRSource))
+        return any(graph.get_worklist(SequenceMLIRArtifact))
 
     def compile(self, graph: CompilationArtifactGraph) -> list[CompilationCommand]:
         commands: list[CompilationCommand] = []
-        worklist = graph.get_worklist(SequenceMLIRSource)
+        worklist = graph.get_worklist(SequenceMLIRArtifact)
         for artifact in worklist:
             callback = partial(fuse_mlir, artifact)
             commands.append(PythonCallbackCompilationCommand(callback))
-            new_artifact = SourceArtifact(artifact.filename)
-            new_artifact.available = True
-            graph.replace(artifact, new_artifact)
+            artifact.available = True
         return commands

--- a/iron/common/sequence.py
+++ b/iron/common/sequence.py
@@ -417,6 +417,27 @@ class OperatorSequence(AIEOperatorBase):
         """Return the runtime callable for the resolved dispatch policy."""
         return self._dispatch.make_callable(self)
 
+    @property
+    def params_path(self):
+        """Path to the ``params.txt`` emitted by ``aie-lower-parameters``.
+
+        ``aie-lower-parameters`` is a module-level pass that assigns
+        globally-unique state-table indices across all devices, so aiecc
+        writes a single ``params.txt`` (per sequence module) inside the
+        per-MLIR project directory it auto-creates next to the sequence MLIR
+        source (``<mlir>.prj/params.txt``).
+
+        Returns ``None`` if no parameters were declared in the sequence module
+        (in which case the file is not written).
+        """
+        from pathlib import Path
+
+        # FullElfArtifact's mlir_input filename is the sequence MLIR source.
+        elf_artifact = self.artifacts[0]
+        mlir_filename = elf_artifact.mlir_input.filename
+        candidate = Path(mlir_filename + ".prj") / "params.txt"
+        return candidate if candidate.exists() else None
+
     def get_layout_for_buffer(self, buffer_name):
         """Return the (buffer_type, offset, length) layout for a named buffer.
 
@@ -447,15 +468,6 @@ def load_elf(op):
     assert isinstance(op.artifacts[0], comp.FullElfArtifact)
     with open(op.artifacts[0].filename, "rb") as f:
         return np.frombuffer(f.read(), dtype=np.uint32)
-
-
-def patch_elf(elf_data, patches):
-    for i, patch in patches.items():
-        val, mask = patch
-        val = np.uint64(val)
-        mask = np.uint64(mask)  # uint32 arithmetic would overflow
-        elf_data[i] = np.uint32((elf_data[i] & ~mask) | (val & mask))
-    return elf_data
 
 
 BF16 = np.dtype(ml_dtypes.bfloat16)
@@ -527,15 +539,14 @@ class SequenceFullELFCallable(SequenceCallable):
     sub-view into whichever consolidated buffer holds the named argument.
     """
 
-    def __init__(self, op, elf_data=None, device_name="main", sequence_name="sequence"):
+    def __init__(self, op, device_name="main", sequence_name="sequence"):
         self.device_name = device_name
         self.sequence_name = sequence_name
-        self.reload_elf(elf_data if elf_data is not None else load_elf(op))
-        super().__init__(op)
 
-    def reload_elf(self, elf_data):
-        # pyxrt.elf takes a PyCapsule wrapping the raw pointer.
+        # Build the XRT kernel from the sequence's compiled ELF.
+        elf_data = load_elf(op)
         elf_data_u8 = elf_data.view(dtype=np.uint8)
+        # pyxrt.elf takes a PyCapsule wrapping the raw pointer.
         ctypes.pythonapi.PyCapsule_New.restype = ctypes.py_object
         ctypes.pythonapi.PyCapsule_New.argtypes = [
             ctypes.c_void_p,
@@ -548,6 +559,36 @@ class SequenceFullELFCallable(SequenceCallable):
         self.xrt_kernel = pyxrt.ext.kernel(
             xrt_context, f"{self.device_name}:{self.sequence_name}"
         )
+
+        super().__init__(op)
+
+        # Persistent run handle: reused across dispatches so that the
+        # ctrl-scratchpad backing buffer (and any ParameterScratchpad state
+        # built on top of it) stays valid across calls.
+        self._run_handle = pyxrt.run(self.xrt_kernel)
+        self._run_handle.set_arg(0, self.input_buffer.buffer_object())
+        self._run_handle.set_arg(1, self.output_buffer.buffer_object())
+        self._run_handle.set_arg(2, self.scratch_buffer.buffer_object())
+
+        self._params = None
+
+    @property
+    def params(self):
+        """Lazy ParameterScratchpad bound to this ELF's ctrl scratchpad BO.
+
+        Returns ``None`` if the sequence has no runtime parameters.
+        """
+        if self._params is not None:
+            return self._params
+        params_path = self.op.params_path
+        if params_path is None or not params_path.exists():
+            return None
+        from aie.utils.hostruntime.xrtruntime.parameter_scratchpad import (
+            ParameterScratchpad,
+        )
+
+        self._params = ParameterScratchpad(self._run_handle, str(params_path))
+        return self._params
 
     def _allocate_buffers(self):
         in_sz, out_sz, scratch_sz = self.op.buffer_sizes
@@ -586,12 +627,8 @@ class SequenceFullELFCallable(SequenceCallable):
         self.output_buffer.to("cpu")
 
     def _run(self):
-        run = pyxrt.run(self.xrt_kernel)
-        run.set_arg(0, self.input_buffer.buffer_object())
-        run.set_arg(1, self.output_buffer.buffer_object())
-        run.set_arg(2, self.scratch_buffer.buffer_object())
-        run.start()
-        ret_code = run.wait()
+        self._run_handle.start()
+        ret_code = self._run_handle.wait()
         if ret_code != pyxrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED:
             raise RuntimeError(f"Kernel execution failed with return code {ret_code}")
 

--- a/iron/common/sequence.py
+++ b/iron/common/sequence.py
@@ -7,7 +7,6 @@ import time
 import numpy as np
 import ml_dtypes
 import pyxrt
-import ctypes
 import torch
 from . import compilation as comp
 from .base import AIEOperatorBase, MLIROperator
@@ -215,7 +214,7 @@ class ReferenceDispatch(SequenceDispatch):
     name = "reference"
 
     def set_up_artifacts(self, seq):
-        pass  # reference mode compiles nothing
+        pass
 
     def make_callable(self, seq):
         return SequenceReferenceCallable(seq)
@@ -306,7 +305,6 @@ class OperatorSequence(AIEOperatorBase):
             {}
         )  # full_buffer_name (with slice) -> (base_name, start, end, args_spec)
 
-        # Collect all buffer specs from operators
         for op, *bufs in self.runlist:
             args_specs = op.get_arg_spec()
             if len(args_specs) != len(bufs):
@@ -332,7 +330,6 @@ class OperatorSequence(AIEOperatorBase):
                             f"Sliced buffer '{buf_name}' requires explicit size for base buffer '{base_name}' in buffer_sizes parameter"
                         )
                 else:
-                    # Regular buffer (no slice)
                     if buf_name not in args:
                         args[buf_name] = args_spec
                     else:
@@ -345,14 +342,12 @@ class OperatorSequence(AIEOperatorBase):
         # Verify all input/output args are present (either as regular or sliced buffers)
         all_buffer_names = set(args.keys()) | set(sliced_buffers.keys())
         for arg in self.input_args:
-            # Check if it's a base buffer name in explicit_buffer_sizes
             if arg not in all_buffer_names and arg not in self.explicit_buffer_sizes:
                 raise ValueError(f"Input argument {arg} not found in runlist buffers")
         for arg in self.output_args:
             if arg not in all_buffer_names and arg not in self.explicit_buffer_sizes:
                 raise ValueError(f"Output argument {arg} not found in runlist buffers")
 
-        # Determine buffer types and create layout
         subbuffer_layout = {}
         slice_info = {}  # full_buffer_name -> (base_name, start, end)
 
@@ -365,7 +360,6 @@ class OperatorSequence(AIEOperatorBase):
                     subbuffer_layout[arg] = (buffer_type, offset, length)
                     offset += length
                 elif arg in args:
-                    # Regular buffer with inferred size
                     arg_spec = args[arg]
                     length = int(
                         np.prod(arg_spec.shape) * np.dtype(arg_spec.dtype).itemsize
@@ -465,9 +459,9 @@ class OperatorSequence(AIEOperatorBase):
 
 
 def load_elf(op):
+    """Build a ``pyxrt.elf`` from the sequence's compiled full-ELF artifact."""
     assert isinstance(op.artifacts[0], comp.FullElfArtifact)
-    with open(op.artifacts[0].filename, "rb") as f:
-        return np.frombuffer(f.read(), dtype=np.uint32)
+    return pyxrt.elf(str(op.artifacts[0].filename))
 
 
 BF16 = np.dtype(ml_dtypes.bfloat16)
@@ -543,18 +537,7 @@ class SequenceFullELFCallable(SequenceCallable):
         self.device_name = device_name
         self.sequence_name = sequence_name
 
-        # Build the XRT kernel from the sequence's compiled ELF.
-        elf_data = load_elf(op)
-        elf_data_u8 = elf_data.view(dtype=np.uint8)
-        # pyxrt.elf takes a PyCapsule wrapping the raw pointer.
-        ctypes.pythonapi.PyCapsule_New.restype = ctypes.py_object
-        ctypes.pythonapi.PyCapsule_New.argtypes = [
-            ctypes.c_void_p,
-            ctypes.c_char_p,
-            ctypes.c_void_p,
-        ]
-        capsule = ctypes.pythonapi.PyCapsule_New(elf_data_u8.ctypes.data, None, None)
-        xrt_elf = pyxrt.elf(capsule, elf_data.nbytes)
+        xrt_elf = load_elf(op)
         xrt_context = pyxrt.hw_context(aie_utils.DefaultNPURuntime._device, xrt_elf)
         self.xrt_kernel = pyxrt.ext.kernel(
             xrt_context, f"{self.device_name}:{self.sequence_name}"

--- a/iron/common/sequence.py
+++ b/iron/common/sequence.py
@@ -110,7 +110,7 @@ class FusedDispatch(SequenceDispatch):
         for op, *bufs in seq.runlist:
             comp_runlist.append((op_names[id(op)], *bufs))
 
-        return comp.SequenceMLIRSource(
+        return comp.SequenceMLIRArtifact(
             seq.name + "_fused.mlir",
             operator_mlir_map=operator_mlir_map,
             runlist=comp_runlist,

--- a/iron/common/sequence.py
+++ b/iron/common/sequence.py
@@ -4,6 +4,7 @@
 import hashlib
 import logging
 import time
+from pathlib import Path
 import numpy as np
 import ml_dtypes
 import pyxrt
@@ -411,27 +412,6 @@ class OperatorSequence(AIEOperatorBase):
         """Return the runtime callable for the resolved dispatch policy."""
         return self._dispatch.make_callable(self)
 
-    @property
-    def params_path(self):
-        """Path to the ``params.txt`` emitted by ``aie-lower-parameters``.
-
-        ``aie-lower-parameters`` is a module-level pass that assigns
-        globally-unique state-table indices across all devices, so aiecc
-        writes a single ``params.txt`` (per sequence module) inside the
-        per-MLIR project directory it auto-creates next to the sequence MLIR
-        source (``<mlir>.prj/params.txt``).
-
-        Returns ``None`` if no parameters were declared in the sequence module
-        (in which case the file is not written).
-        """
-        from pathlib import Path
-
-        # FullElfArtifact's mlir_input filename is the sequence MLIR source.
-        elf_artifact = self.artifacts[0]
-        mlir_filename = elf_artifact.mlir_input.filename
-        candidate = Path(mlir_filename + ".prj") / "params.txt"
-        return candidate if candidate.exists() else None
-
     def get_layout_for_buffer(self, buffer_name):
         """Return the (buffer_type, offset, length) layout for a named buffer.
 
@@ -456,12 +436,6 @@ class OperatorSequence(AIEOperatorBase):
 # ##########################################################################
 # Module helpers
 # ##########################################################################
-
-
-def load_elf(op):
-    """Build a ``pyxrt.elf`` from the sequence's compiled full-ELF artifact."""
-    assert isinstance(op.artifacts[0], comp.FullElfArtifact)
-    return pyxrt.elf(str(op.artifacts[0].filename))
 
 
 BF16 = np.dtype(ml_dtypes.bfloat16)
@@ -537,7 +511,8 @@ class SequenceFullELFCallable(SequenceCallable):
         self.device_name = device_name
         self.sequence_name = sequence_name
 
-        xrt_elf = load_elf(op)
+        assert isinstance(op.artifacts[0], comp.FullElfArtifact)
+        xrt_elf = pyxrt.elf(str(op.artifacts[0].filename))
         xrt_context = pyxrt.hw_context(aie_utils.DefaultNPURuntime._device, xrt_elf)
         self.xrt_kernel = pyxrt.ext.kernel(
             xrt_context, f"{self.device_name}:{self.sequence_name}"
@@ -548,10 +523,10 @@ class SequenceFullELFCallable(SequenceCallable):
         # Persistent run handle: reused across dispatches so that the
         # ctrl-scratchpad backing buffer (and any ParameterScratchpad state
         # built on top of it) stays valid across calls.
-        self._run_handle = pyxrt.run(self.xrt_kernel)
-        self._run_handle.set_arg(0, self.input_buffer.buffer_object())
-        self._run_handle.set_arg(1, self.output_buffer.buffer_object())
-        self._run_handle.set_arg(2, self.scratch_buffer.buffer_object())
+        self.run_handle = pyxrt.run(self.xrt_kernel)
+        self.run_handle.set_arg(0, self.input_buffer.buffer_object())
+        self.run_handle.set_arg(1, self.output_buffer.buffer_object())
+        self.run_handle.set_arg(2, self.scratch_buffer.buffer_object())
 
         self._params = None
 
@@ -559,18 +534,22 @@ class SequenceFullELFCallable(SequenceCallable):
     def params(self):
         """Lazy ParameterScratchpad bound to this ELF's ctrl scratchpad BO.
 
-        Returns ``None`` if the sequence has no runtime parameters.
+        The ``params.txt`` describing the runtime parameters is written by
+        ``aie-lower-parameters`` into the ``<mlir>.prj`` project directory next
+        to the fused MLIR source. Returns ``None`` if the sequence declared no
+        runtime parameters (in which case the file is not written).
         """
         if self._params is not None:
             return self._params
-        params_path = self.op.params_path
-        if params_path is None or not params_path.exists():
+        mlir_filename = self.op.artifacts[0].mlir_input.filename
+        params_path = Path(mlir_filename + ".prj") / "params.txt"
+        if not params_path.exists():
             return None
         from aie.utils.hostruntime.xrtruntime.parameter_scratchpad import (
             ParameterScratchpad,
         )
 
-        self._params = ParameterScratchpad(self._run_handle, str(params_path))
+        self._params = ParameterScratchpad(self.run_handle, str(params_path))
         return self._params
 
     def _allocate_buffers(self):
@@ -610,8 +589,8 @@ class SequenceFullELFCallable(SequenceCallable):
         self.output_buffer.to("cpu")
 
     def _run(self):
-        self._run_handle.start()
-        ret_code = self._run_handle.wait()
+        self.run_handle.start()
+        ret_code = self.run_handle.wait()
         if ret_code != pyxrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED:
             raise RuntimeError(f"Kernel execution failed with return code {ret_code}")
 

--- a/iron/operators/softmax/design.py
+++ b/iron/operators/softmax/design.py
@@ -7,6 +7,7 @@ import numpy as np
 from aie.iron import (
     Kernel,
     ObjectFifo,
+    ScratchpadParameter,
     Program,
     Runtime,
     Worker,
@@ -27,7 +28,7 @@ def softmax(
     trace_size,
     tile_size,
     rtp_vector_size=None,
-    mask_patch_value=0,
+    vector_size_parameter=None,
     func_prefix="",
     kernel_obj_file="softmax.o",
 ):
@@ -72,10 +73,24 @@ def softmax(
         [tile_ty, np.int32, np.int32],
     )
 
-    # Define a task that will run on a compute tile
-    def core_body(of_in1, of_out, softmax_kernel, mask_kernel, rtp, barrier):
+    # Vector size source: either a scratchpad Parameter (synced from host each
+    # dispatch) or a write-RTP buffer set via rt.inline_ops at compile time.
+    use_scratchpad = vector_size_parameter is not None
+    vector_size_param = (
+        ScratchpadParameter(vector_size_parameter, np.int32) if use_scratchpad else None
+    )
+
+    def core_body(
+        of_in1, of_out, softmax_kernel, mask_kernel, vector_size_src, barrier
+    ):
         barrier.wait_for_value(1)
-        vector_size = rtp[0]
+        # `use_scratchpad` is a compile-time constant, so only one of these
+        # branches is emitted into the core: a scratchpad Parameter read or a
+        # write-RTP buffer load.
+        if use_scratchpad:
+            vector_size = vector_size_src.read()
+        else:
+            vector_size = vector_size_src[0]
         for _ in range_(N_div_n):
             elem_in1 = of_in1.acquire(1)
             elem_out = of_out.acquire(1)
@@ -84,15 +99,19 @@ def softmax(
             of_in1.release(1)
             of_out.release(1)
 
-    rtps = [
-        Buffer(
-            np.ndarray[(1,), np.dtype[np.int32]],
-            name=f"rtp_{i}_{j}",
-            use_write_rtp=True,
-        )
-        for i in range(num_aie_columns)
-        for j in range(num_channels)
-    ]
+    rtps = (
+        []
+        if use_scratchpad
+        else [
+            Buffer(
+                np.ndarray[(1,), np.dtype[np.int32]],
+                name=f"rtp_{i}_{j}",
+                use_write_rtp=True,
+            )
+            for i in range(num_aie_columns)
+            for j in range(num_channels)
+        ]
+    )
 
     barriers = [
         WorkerRuntimeBarrier()
@@ -101,14 +120,18 @@ def softmax(
     ]
 
     # Create a worker to run the task on a compute tile
-    worker_args = lambda i, j: [
-        of_in1s[i * num_channels + j].cons(),
-        of_outs[i * num_channels + j].prod(),
-        softmax_kernel,
-        mask_kernel,
-        rtps[i * num_channels + j],
-        barriers[i * num_channels + j],
-    ]
+    def worker_args(i, j):
+        idx = i * num_channels + j
+        per_core_runtime = vector_size_param if use_scratchpad else rtps[idx]
+        return [
+            of_in1s[idx].cons(),
+            of_outs[idx].prod(),
+            softmax_kernel,
+            mask_kernel,
+            per_core_runtime,
+            barriers[idx],
+        ]
+
     my_workers = [
         Worker(core_body, worker_args(i, j))
         for i in range(num_aie_columns)
@@ -136,16 +159,19 @@ def softmax(
     with rt.sequence(tensor_ty, tensor_ty) as (A, C):
         rt.start(*my_workers)
 
-        # Set run-time parameter controlling how many elements each core processes:
-        # - Normal case (mask_patch_value == 0): set to rtp_vector_size (the actual active row width;
-        #   elements beyond this are padding and are ignored by the softmax computation).
-        # - Masked case (mask_patch_value != 0): set to mask_patch_value, which the mask kernel uses
-        #   as a threshold to zero out elements beyond the unmasked patch boundary before softmax.
-        def set_rtps(*args):
-            for rtp in args:
-                rtp[0] = mask_patch_value if mask_patch_value else rtp_vector_size
+        if use_scratchpad:
+            # The host writes vector_size into the scratchpad via
+            # ParameterScratchpad before each dispatch; sync delivers it to the
+            # per-core parameter buffer.
+            rt.sync_parameters()
+        else:
+            # Set the static (compile-time) run-time parameter controlling how
+            # many elements each core processes.
+            def set_rtps(*args):
+                for rtp in args:
+                    rtp[0] = rtp_vector_size
 
-        rt.inline_ops(set_rtps, rtps)
+            rt.inline_ops(set_rtps, rtps)
 
         for i in range(num_aie_columns * num_channels):
             rt.set_barrier(barriers[i], 1)

--- a/iron/operators/softmax/op.py
+++ b/iron/operators/softmax/op.py
@@ -27,7 +27,7 @@ class Softmax(MLIROperator):
     num_aie_columns: int = 1
     num_channels: int = 1
     rtp_vector_size: int | None = None
-    mask_patch_value: int = 0
+    vector_size_parameter: str | None = None
     context: object = field(default=None, repr=False)
 
     @property
@@ -67,7 +67,7 @@ class Softmax(MLIROperator):
                     "trace_size": 0,
                     "tile_size": self.cols,
                     "rtp_vector_size": self.rtp_vector_size,
-                    "mask_patch_value": self.mask_patch_value,
+                    "vector_size_parameter": self.vector_size_parameter,
                     "kernel_obj_file": self._kernel_link_file,
                 },
             ),

--- a/iron/operators/strided_copy/design.py
+++ b/iron/operators/strided_copy/design.py
@@ -11,7 +11,7 @@ input[0, :, 0] -> output[:, 0, 0]
 import numpy as np
 
 from aie.dialects.aiex import TensorAccessPattern
-from aie.iron import ObjectFifo, Program, Runtime
+from aie.iron import ObjectFifo, ScratchpadParameter, Program, Runtime
 
 
 def strided_copy(
@@ -27,8 +27,8 @@ def strided_copy(
     output_offset,
     transfer_size=None,
     num_aie_channels=1,
-    input_offset_patch_marker=0,
-    output_offset_patch_marker=0,
+    input_offset_parameter=None,
+    output_offset_parameter=None,
 ):
     assert len(input_sizes) == len(input_strides)
     assert len(output_sizes) == len(output_strides)
@@ -65,20 +65,28 @@ def strided_copy(
         np.dtype[dtype],
     ]
 
-    # input_offset_patch_marker (and output_offset_patch_marker) is a deferred-offset mechanism:
-    # When non-zero, it is used as a placeholder offset value in the TensorAccessPattern instead
-    # of the statically-computed input_offset. The actual offset is then patched at runtime by the
-    # caller (e.g., StridedCopy.forward()) by writing the real byte offset into the instruction
-    # stream. This allows the same compiled xclbin/insts to be reused with different runtime offsets
-    # into a shared buffer, without recompilation. The tensor_dims is also expanded by the marker
-    # value to prevent the compiler from flagging out-of-bounds accesses during code generation.
+    # input_offset_parameter (and output_offset_parameter) is the name of an
+    # aiex.scratchpad_parameter used to patch the DMA BD base address at runtime. The
+    # statically-computed offset is used as the base; the parameter's value is
+    # additively combined onto it inside the BD address registers via UPDATE_REG.
+    # The host writes the byte offset into the ctrl scratchpad before each
+    # dispatch via ParameterScratchpad.
+    in_offset_param = (
+        ScratchpadParameter(input_offset_parameter, np.int32)
+        if input_offset_parameter is not None
+        else None
+    )
+    out_offset_param = (
+        ScratchpadParameter(output_offset_parameter, np.int32)
+        if output_offset_parameter is not None
+        else None
+    )
+
     input_taps = [
         TensorAccessPattern(
-            tensor_dims=(int(input_buffer_size + input_offset_patch_marker),),
+            tensor_dims=(int(input_buffer_size),),
             offset=(
-                input_offset_patch_marker
-                if input_offset_patch_marker != 0
-                else input_offset
+                input_offset
                 + c
                 * (input_sizes[input_highest_sz_idx] // num_aie_channels)
                 * input_strides[input_highest_sz_idx]
@@ -95,11 +103,9 @@ def strided_copy(
 
     output_taps = [
         TensorAccessPattern(
-            tensor_dims=(int(output_buffer_size + output_offset_patch_marker),),
+            tensor_dims=(int(output_buffer_size),),
             offset=(
-                output_offset_patch_marker
-                if output_offset_patch_marker != 0
-                else output_offset
+                output_offset
                 + c
                 * (output_sizes[output_highest_sz_idx] // num_aie_channels)
                 * output_strides[output_highest_sz_idx]
@@ -126,10 +132,25 @@ def strided_copy(
 
     rt = Runtime()
     with rt.sequence(inp_ty, out_ty) as (inp, out):
+        if in_offset_param is not None or out_offset_param is not None:
+            rt.sync_parameters()
         tg = rt.task_group()
         for c in range(num_aie_channels):
-            rt.fill(fifos_in[c].prod(), inp, input_taps[c], task_group=tg)
-            rt.drain(fifos_out[c].cons(), out, output_taps[c], task_group=tg, wait=True)
+            rt.fill(
+                fifos_in[c].prod(),
+                inp,
+                input_taps[c],
+                task_group=tg,
+                offset_parameter=in_offset_param,
+            )
+            rt.drain(
+                fifos_out[c].cons(),
+                out,
+                output_taps[c],
+                task_group=tg,
+                wait=True,
+                offset_parameter=out_offset_param,
+            )
         rt.finish_task_group(tg)
 
     return Program(dev, rt).resolve_program()

--- a/iron/operators/strided_copy/op.py
+++ b/iron/operators/strided_copy/op.py
@@ -30,6 +30,8 @@ class StridedCopy(MLIROperator):
     dtype: object = field(default=bfloat16, repr=False)
     transfer_size: int | None = None
     num_aie_channels: int = 1
+    input_offset_parameter: str | None = None
+    output_offset_parameter: str | None = None
     kwargs: dict = field(default_factory=dict, repr=False)
     context: object = field(default=None, repr=False)
 
@@ -43,6 +45,8 @@ class StridedCopy(MLIROperator):
         "output_offset": "ooff",
         "transfer_size": "tr",
         "num_aie_channels": "ch",
+        "input_offset_parameter": "ipar",
+        "output_offset_parameter": "opar",
     }
 
     def __post_init__(self):
@@ -78,7 +82,11 @@ class StridedCopy(MLIROperator):
                     self.transfer_size,
                     self.num_aie_channels,
                 ),
-                self.kwargs,
+                {
+                    **self.kwargs,
+                    "input_offset_parameter": self.input_offset_parameter,
+                    "output_offset_parameter": self.output_offset_parameter,
+                },
             ),
         )
 

--- a/iron/tests/infrastructure/sequence.py
+++ b/iron/tests/infrastructure/sequence.py
@@ -35,10 +35,6 @@ from iron.operators.elementwise_add.op import ElementwiseAdd
 from iron.operators.relu.op import ReLU
 
 
-def _is_npu2():
-    return isinstance(aie_utils.get_current_device(), NPU2)
-
-
 def _set_input(run, name, data):
     """Write a host tensor into an input buffer and push it to the device.
 
@@ -106,7 +102,9 @@ def test_auto_dispatch_selects_platform_default(size, aie_context):
     seq = _build_add_relu_sequence(aie_context, "auto", "infra_auto_add_relu")
     seq.compile()
 
-    expected_mode = "fused" if _is_npu2() else "separate"
+    expected_mode = (
+        "fused" if isinstance(aie_utils.get_current_device(), NPU2) else "separate"
+    )
     assert seq._dispatch.name == expected_mode, (
         f"auto dispatch resolved to {seq._dispatch.name!r}, expected "
         f"{expected_mode!r} on this device"
@@ -187,7 +185,7 @@ def test_dispatch_modes_bit_identical(dispatch, aie_context):
     dispatch mode: the compiled kernels are the same, so only the dispatch
     mechanism differs. The ``separate`` mode is the baseline (it runs on every
     platform)."""
-    if dispatch == "fused" and not _is_npu2():
+    if dispatch == "fused" and not isinstance(aie_utils.get_current_device(), NPU2):
         pytest.skip("fused (single-ELF) dispatch requires NPU2")
 
     torch.manual_seed(0)


### PR DESCRIPTION
Replace the ugly magic-value patching in the llama example application for run-time parameters with the new ScratchpadParameter feature in MLIR-AIE.

Builds on #117 -- [isolated diff](https://github.com/andrej/IRON/compare/fused-dispatch-modes...scratchpad)