### PR TITLE
Update MLIR-AIE to pick up ObjectFIFO fix and re-enable MHA

### DIFF
--- a/iron/operators/mha/test.py
+++ b/iron/operators/mha/test.py
@@ -28,7 +28,6 @@ def get_params():
     ]
 
 
-@pytest.mark.skip(reason="Temporarily disabled")
 @pytest.mark.supported_devices("npu2")
 @pytest.mark.metrics(
     Latency=r"Latency \(us\): (?P<value>[\d\.]+)",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@
 # version of torch (don't need CUDA), so we give this index precedence over the
 # main PyPI. These indices are consulted in order of precedence by pip.
 --index-url https://download.pytorch.org/whl/cpu
---extra-index-url https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.3.4
+--extra-index-url https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4
 --extra-index-url https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 --extra-index-url https://pypi.org/simple
 
-mlir_aie==v1.3.4
+mlir_aie==1.3.5.dev20+g167f34d
 llvm-aie==21.0.0.2026062301+cb664e8c
 
 black


### PR DESCRIPTION
Pick up https://github.com/Xilinx/mlir-aie/pull/3295 and re-enable MHA test that relies on this fix

closes #130 