### PR TITLE
compilation: honor AIECC_PATH and AIECC_JOBS env overrides

### DIFF
--- a/iron/common/compilation/base.py
+++ b/iron/common/compilation/base.py
@@ -490,7 +490,14 @@ class AieccCompilationRule(CompilationRule):
         self, build_dir, peano_dir, mlir_aie_dir, use_chess=False, *args, **kwargs
     ):
         self.build_dir = build_dir
-        self.aiecc_path = Path(mlir_aie_dir) / "bin" / "aiecc"
+        # AIECC_PATH lets a build point at a locally-built aiecc (e.g. a compiler under
+        # development) without replacing the installed one. Default = the installed aiecc.
+        _aiecc_override = os.environ.get("AIECC_PATH")
+        self.aiecc_path = (
+            Path(_aiecc_override)
+            if _aiecc_override
+            else Path(mlir_aie_dir) / "bin" / "aiecc"
+        )
         self.peano_dir = peano_dir
         self.use_chess = use_chess
         super().__init__(*args, **kwargs)
@@ -508,7 +515,7 @@ class AieccFullElfCompilationRule(AieccCompilationRule):
             compile_cmd = [
                 str(self.aiecc_path),
                 "-v",
-                "-j1",
+                f"-j{os.environ.get('AIECC_JOBS', '1')}",
                 "--no-compile-host",
             ]
             if self.use_chess:
@@ -562,7 +569,7 @@ class AieccXclbinInstsCompilationRule(AieccCompilationRule):
             compile_cmd = [
                 str(self.aiecc_path),
                 "-v",
-                "-j1",
+                f"-j{os.environ.get('AIECC_JOBS', '1')}",
                 "--no-compile-host",
             ]
             if self.use_chess:


### PR DESCRIPTION
Two opt-in, backward-compatible build-ergonomics knobs on the aiecc compilation rules. Both default to the current behavior, so nothing changes unless the env var is set.

- **`AIECC_PATH`** - point the compilation rules at a locally-built `aiecc` (for example a compiler under active development) instead of the one under `mlir_aie_dir/bin`, without having to overwrite the installed binary. Default: the installed `aiecc`.
- **`AIECC_JOBS`** - pass `-j<N>` to `aiecc` instead of the hardcoded `-j1`, so multi-core hosts can compile the AIE cores in parallel. Default `1` = unchanged.

Both are read via `os.environ.get(...)` in `iron/common/compilation/base.py` (the `aiecc` path resolution and the two `Aiecc*CompilationRule` command builders). No new dependencies.
