### PR TITLE
Windows support

### DIFF
--- a/iron/applications/llama_3.2_1b/test.py
+++ b/iron/applications/llama_3.2_1b/test.py
@@ -5,6 +5,7 @@
 import subprocess
 import pytest
 import os
+import sys
 from pathlib import Path
 
 test_dir = Path(__file__).parent
@@ -27,6 +28,7 @@ def generate_test_params():
 params, names = generate_test_params()
 
 
+@pytest.mark.skipif(not weights_dir.exists(), reason="llama3.2-1b not found")
 @pytest.mark.supported_devices("npu2")
 @pytest.mark.metrics(
     TTFT=r"\[Prefill\]\s*Time to first token:\s*(?P<value>[\d\.e\+-]+) s",
@@ -34,7 +36,7 @@ params, names = generate_test_params()
 )
 @pytest.mark.parametrize("prompt_len,num_tokens", params, ids=names)
 def test_llama_3_2_1b(prompt_len, num_tokens):
-    command = f"python3 {test_dir}/llama_npu.py {weights_dir}/llama3.2-1b/model.safetensors {weights_dir}/llama3.2-1b/tokenizer.model --num-tokens {num_tokens} --prompt-len {prompt_len}"
+    command = f"{sys.executable} {test_dir}/llama_npu.py {weights_dir}/llama3.2-1b/model.safetensors {weights_dir}/llama3.2-1b/tokenizer.model --num-tokens {num_tokens} --prompt-len {prompt_len}"
 
     result = subprocess.run(
         command,

--- a/iron/applications/llama_3.2_1b/test.py
+++ b/iron/applications/llama_3.2_1b/test.py
@@ -28,7 +28,13 @@ def generate_test_params():
 params, names = generate_test_params()
 
 
-@pytest.mark.skipif(not weights_dir.exists(), reason="llama3.2-1b not found")
+@pytest.mark.skipif(
+    not (
+        (weights_dir / "llama3.2-1b" / "model.safetensors").exists()
+        and (weights_dir / "llama3.2-1b" / "tokenizer.model").exists()
+    ),
+    reason="llama3.2-1b weights not found",
+)
 @pytest.mark.supported_devices("npu2")
 @pytest.mark.metrics(
     TTFT=r"\[Prefill\]\s*Time to first token:\s*(?P<value>[\d\.e\+-]+) s",

--- a/iron/common/compilation/base.py
+++ b/iron/common/compilation/base.py
@@ -746,13 +746,29 @@ class KernelCompilationRule(CompilationRule):
         nm_path = self._find_tool("llvm-nm")
         symbol_map_file = artifact.filename + ".symbol_map"
 
-        # Extract defined symbols and create symbol map
-        nm_cmd = [
-            "sh",
-            "-c",
-            f"{nm_path} --defined-only --extern-only {artifact.filename} | "
-            f"awk '{{print $3 \" {prefix}\" $3}}' > {symbol_map_file}",
-        ]
+        if os.name == "nt":
+            # Pure python code execution block wrapped cleanly for Windows
+            python_script = f"""
+import subprocess
+nm_cmd = [{repr(nm_path)}, '--defined-only', '--extern-only', {repr(artifact.filename)}]
+res = subprocess.run(nm_cmd, capture_output=True, text=True, check=True)
+lines = []
+for line in res.stdout.splitlines():
+    parts = line.strip().split()
+    if len(parts) >= 3:
+        sym = parts[-1]
+        lines.append(f"{{sym}} {prefix}{{sym}}\\n")
+with open({repr(symbol_map_file)}, 'w') as f:
+    f.writelines(lines)
+"""
+            nm_cmd = [sys.executable, "-c", python_script.strip()]
+        else:
+            # Standard Unix fallback path
+            nm_cmd = [
+                "sh", "-c", 
+                f"{nm_path} --defined-only --extern-only {artifact.filename} | "
+                f"awk '{{print $3 \" {prefix}\" $3}}' > {symbol_map_file}",
+            ]
 
         # Apply the renaming using the symbol map
         objcopy_cmd = [

--- a/iron/common/compilation/base.py
+++ b/iron/common/compilation/base.py
@@ -772,7 +772,8 @@ with open({repr(symbol_map_file)}, 'w') as f:
         else:
             # Standard Unix fallback path
             nm_cmd = [
-                "sh", "-c", 
+                "sh",
+                "-c",
                 f"{nm_path} --defined-only --extern-only {artifact.filename} | "
                 f"awk '{{print $3 \" {prefix}\" $3}}' > {symbol_map_file}",
             ]

--- a/iron/operators/mha/design.py
+++ b/iron/operators/mha/design.py
@@ -554,12 +554,12 @@ def fused_mha(
                 idx_buffer[0] += 1
                 ###
 
-                with if_(loop_idx_kv > 2) as if_op:
-                    for _ in range_(loop_idx_kv - 2):
-                        elem_in_p = of_p.acquire(1)
-                        elem_in_v = of_v.acquire(1)
-                        elt_of_out_scale2 = of_scale.acquire(1)
-
+                
+                for _ in range_(loop_idx_kv - 2):
+                    elem_in_p = of_p.acquire(1)
+                    elem_in_v = of_v.acquire(1)
+                    elt_of_out_scale2 = of_scale.acquire(1)
+                    with if_(loop_idx_kv > 2) as if_op:
                         matmul_PV(
                             elem_in_p,
                             elem_in_v,
@@ -569,19 +569,17 @@ def fused_mha(
                             1,
                             idx_buffer,
                         )
-
-                        of_p.release(1)
-                        of_v.release(1)
-                        of_scale.release(1)
-
                         idx_buffer[0] += 1
 
-                ### Last iteration, final rescaling
-                with if_(loop_idx_kv > 1) as if_op:
-                    elem_in_p = of_p.acquire(1)
-                    elem_in_v = of_v.acquire(1)
-                    elt_of_out_scale3 = of_scale.acquire(1)
+                    of_p.release(1)
+                    of_v.release(1)
+                    of_scale.release(1)
 
+                ### Last iteration, final rescaling
+                elem_in_p = of_p.acquire(1)
+                elem_in_v = of_v.acquire(1)
+                elt_of_out_scale3 = of_scale.acquire(1)
+                with if_(loop_idx_kv > 1) as if_op:
                     matmul_PV(
                         elem_in_p,
                         elem_in_v,
@@ -592,12 +590,11 @@ def fused_mha(
                         idx_buffer,
                     )
                     rescale_O(elem_o_out, elt_of_out_scale3, B_q, idx_buffer)
-
-                    of_p.release(1)
-                    of_v.release(1)
-                    of_scale.release(1)
-
                     idx_buffer[0] += 1
+                of_p.release(1)
+                of_v.release(1)
+                of_scale.release(1)
+
                 # else:
                 with else_(if_op):
                     rescale_O(elem_o_out, elt_of_out_scale, B_q, idx_buffer)

--- a/iron/operators/mha/design.py
+++ b/iron/operators/mha/design.py
@@ -554,12 +554,12 @@ def fused_mha(
                 idx_buffer[0] += 1
                 ###
 
-                
-                for _ in range_(loop_idx_kv - 2):
-                    elem_in_p = of_p.acquire(1)
-                    elem_in_v = of_v.acquire(1)
-                    elt_of_out_scale2 = of_scale.acquire(1)
-                    with if_(loop_idx_kv > 2) as if_op:
+                with if_(loop_idx_kv > 2) as if_op:
+                    for _ in range_(loop_idx_kv - 2):
+                        elem_in_p = of_p.acquire(1)
+                        elem_in_v = of_v.acquire(1)
+                        elt_of_out_scale2 = of_scale.acquire(1)
+
                         matmul_PV(
                             elem_in_p,
                             elem_in_v,
@@ -569,17 +569,19 @@ def fused_mha(
                             1,
                             idx_buffer,
                         )
+
+                        of_p.release(1)
+                        of_v.release(1)
+                        of_scale.release(1)
+
                         idx_buffer[0] += 1
 
-                    of_p.release(1)
-                    of_v.release(1)
-                    of_scale.release(1)
-
                 ### Last iteration, final rescaling
-                elem_in_p = of_p.acquire(1)
-                elem_in_v = of_v.acquire(1)
-                elt_of_out_scale3 = of_scale.acquire(1)
                 with if_(loop_idx_kv > 1) as if_op:
+                    elem_in_p = of_p.acquire(1)
+                    elem_in_v = of_v.acquire(1)
+                    elt_of_out_scale3 = of_scale.acquire(1)
+
                     matmul_PV(
                         elem_in_p,
                         elem_in_v,
@@ -590,11 +592,12 @@ def fused_mha(
                         idx_buffer,
                     )
                     rescale_O(elem_o_out, elt_of_out_scale3, B_q, idx_buffer)
-                    idx_buffer[0] += 1
-                of_p.release(1)
-                of_v.release(1)
-                of_scale.release(1)
 
+                    of_p.release(1)
+                    of_v.release(1)
+                    of_scale.release(1)
+
+                    idx_buffer[0] += 1
                 # else:
                 with else_(if_op):
                     rescale_O(elem_o_out, elt_of_out_scale, B_q, idx_buffer)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

Describe the intent of your PR here. Added Windows support, pretty self explanatory and should have been included from the beginning. (I'm aware the llvm and mlir dependencies were the main limiting factor).

## Added
- Added test skip validation for missing gated weights to stabilize local test executions.

## Changed
- Switched to using ``time.perf_counter_ns`` to prevent divide by 0 errors.
- Hoisted object FIFO acquires out of conditional structures to satisfy cyclostatic compiler analysis constraints.
- Swapped shell/awk commands for platform-independent Python execution blocks to handle symbol mapping on Windows.


## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.

```
================================================== warnings summary ===================================================
iron/operators/dequant/test.py::test_dequant[iter0-input_length_1024-num_aie_columns_1-num_channels_1-tile_size_1024-group_size_32]
  D:\IRON\iron\operators\dequant\reference.py:42: UserWarning: torch.quantize_per_tensor, torch.quantize_per_channel and other quantized tensor creation functions that produce tensors with dtype torch.quint8, torch.qint8, and torch.qint32 are deprecated and will be removed in a future PyTorch release. Please see https://github.com/pytorch/pytorch/issues/184982 for more information. (Triggered internally at D:/b/torch/aten/src/ATen/quantized/Quantizer.cpp:116.)
    A = torch.quantize_per_channel(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================== 2830 passed, 25 skipped, 1 warning in 1032.96s (0:17:12) ===============================
```
The test run results shown above was faster because I left the build folder in place after realizing how to fix the divide by 0 error I was encountering with the `latency_us` calculations, it had previously taken `2029.72s (0:33:49)`. 

I used the `llvm-aie`, `mlir-aie-no-rtti`  and `mlir-air` that were installed when I installed triton-windows. The restrictions in `requirements.txt` are too strict for the versions and there was no windows wheel for those.

```
llvm-aie                   21.0.0.2026071801+ce8c0f8f
mlir-aie-no-rtti           1.3.4.dev19+g92e9475
mlir-air                   0.0.1.2026071405+c7ee42f.no.rtti
```