### PR TITLE
fusion: don't let a broken llvm-nm silently drop the symbol prefix

### DIFF
--- a/iron/common/compilation/base.py
+++ b/iron/common/compilation/base.py
@@ -651,6 +651,45 @@ def _find_tool(name, peano_dir, mlir_aie_dir):
     )
 
 
+def _tool_runs(path):
+    """True if the tool at `path` actually executes. Guards against a binary that
+    is present on disk but cannot run -- e.g. one whose shared-library
+    dependency fails to load, so it exits nonzero and emits nothing rather than
+    producing output."""
+    try:
+        return (
+            subprocess.run([str(path), "--version"], capture_output=True).returncode
+            == 0
+        )
+    except OSError:
+        return False
+
+
+def _find_working_tool(name, peano_dir, mlir_aie_dir):
+    """Like _find_tool, but skip candidates that are present-but-broken (fail to
+    run) and fall through to the next, ending at the system PATH copy.
+
+    _find_tool returns the FIRST *existing* binary even if it cannot run. Used
+    silently in a `nm | awk > map` pipeline such a binary yields an EMPTY symbol
+    map (the pipe's exit status is awk's, so nm's failure is masked) -> the
+    fusion symbol prefix is never applied -> `undefined symbol: <prefix><sym>`
+    at the per-core link."""
+    candidates = [
+        Path(peano_dir) / "bin" / name,
+        Path(mlir_aie_dir) / "bin" / name,
+    ]
+    for tool_name in (name, f"{name}-18"):
+        found = shutil.which(tool_name)
+        if found:
+            candidates.append(Path(found))
+    for candidate in candidates:
+        if candidate.is_file() and _tool_runs(candidate):
+            return str(candidate)
+    # Nothing ran cleanly: defer to _find_tool (existence-only) so the caller
+    # still gets a path, or its clear FileNotFoundError if none exists at all.
+    return _find_tool(name, peano_dir, mlir_aie_dir)
+
+
 class KernelCompilationRule(CompilationRule):
     """Compile KernelObjectArtifacts using Peano (clang++) or xchesscc."""
 
@@ -730,8 +769,11 @@ class KernelCompilationRule(CompilationRule):
     def _find_tool(self, name):
         return _find_tool(name, self.peano_dir, self.mlir_aie_dir)
 
+    def _find_working_tool(self, name):
+        return _find_working_tool(name, self.peano_dir, self.mlir_aie_dir)
+
     def _rename_symbols(self, artifact):
-        objcopy_path = self._find_tool("llvm-objcopy")
+        objcopy_path = self._find_working_tool("llvm-objcopy")
         cmd = [objcopy_path]
         for old_sym, new_sym in artifact.rename_symbols.items():
             cmd += [
@@ -742,16 +784,23 @@ class KernelCompilationRule(CompilationRule):
         return [ShellCompilationCommand(cmd)]
 
     def _prefix_symbols(self, artifact, prefix):
-        objcopy_path = self._find_tool("llvm-objcopy")
-        nm_path = self._find_tool("llvm-nm")
+        objcopy_path = self._find_working_tool("llvm-objcopy")
+        nm_path = self._find_working_tool("llvm-nm")
         symbol_map_file = artifact.filename + ".symbol_map"
 
-        # Extract defined symbols and create symbol map
+        # Extract defined symbols and build the redefine-syms map. Run nm to a
+        # file, THEN awk (joined by `&&`) rather than `nm | awk`: a pipe reports
+        # only awk's exit status, so a failing nm silently produces an EMPTY map
+        # and the prefix rename is skipped, surfacing much later as
+        # `undefined symbol: {prefix}<sym>` at the per-core link. With `&&` a
+        # failed nm aborts here loudly instead.
         nm_cmd = [
             "sh",
             "-c",
-            f"{nm_path} --defined-only --extern-only {artifact.filename} | "
-            f"awk '{{print $3 \" {prefix}\" $3}}' > {symbol_map_file}",
+            f"{nm_path} --defined-only --extern-only {artifact.filename} "
+            f"> {symbol_map_file}.syms && "
+            f"awk '{{print $3 \" {prefix}\" $3}}' {symbol_map_file}.syms "
+            f"> {symbol_map_file}",
         ]
 
         # Apply the renaming using the symbol map


### PR DESCRIPTION

### Summary

`KernelCompilationRule._prefix_symbols` builds a redefine-syms map with
`nm --defined-only --extern-only obj | awk '...' > map` and applies it with
`objcopy --redefine-syms=map`. If `nm` fails, the map comes out empty, `objcopy` renames nothing, and every
fused kernel object keeps its bare symbol, which surfaces only much later as `undefined symbol: <prefix><sym>`
at the per-core link. Two things make that failure silent:

1. `_find_tool` returns the first existing `llvm-nm` / `llvm-objcopy` even if that binary cannot actually
   run (for example one with an unsatisfied shared-library dependency).
2. In `nm | awk > map` the pipeline's exit status is `awk`'s, so a failure of `nm` is masked.

### Fix

- Add `_find_working_tool`, which probes each candidate with `--version` and skips a present-but-unrunnable
  binary, falling through to the system PATH copy and finally to `_find_tool` (so the existing not-found
  error is preserved). `_prefix_symbols` and `_rename_symbols` use it to select `llvm-nm` / `llvm-objcopy`.
- Run `nm` to a file joined to `awk` with `&&`, so a failing `nm` aborts the build loudly instead of
  yielding an empty map.

Both changes are no-ops when the tools work: the same binary is selected and the same map is produced.

### Testing

Reproduced the original silent failure by selecting an `llvm-nm` that exits nonzero; before the change the
fused link failed with `undefined symbol: <prefix><sym>`, and after it the build either succeeds (a working
`nm` is found on PATH) or aborts at the map step with `nm`'s own error, instead of failing opaquely at link
time. No behavior change when `nm` / `objcopy` run normally.
