### PR TITLE
ci: check out trusted base in pr-comment, not the fork head_sha

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -30,8 +30,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+        # No ref: check out the default branch (trusted base code). This job
+        # runs from workflow_run with a write-scoped GITHUB_TOKEN and secrets,
+        # so it must not check out the fork's head_sha: actions/checkout now
+        # refuses that (pwn-request guard), and running the fork's copy of
+        # ci/scripts/pretty_aggregate.py under the write token would be the
+        # vulnerability itself. The job only needs the trusted aggregation
+        # script; artifacts and PR metadata come from the API, not the tree.
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
The "Comment on PR with Test Results" workflow (`.github/workflows/pr-comment.yml`) fails its checkout step on every fork PR. For example, run 30051409584 aborts with:

```
Refusing to check out fork pull request code from a 'workflow_run' workflow.
```

The step uses `ref: ${{ github.event.workflow_run.head_sha }}`. For a fork PR that head_sha is the fork's commit, and recent `actions/checkout` refuses to check out fork code inside a `workflow_run` job. So the comment job goes red even when the Krackan/Phoenix suites all passed, which trains people to ignore failures on this check.

There are two problems, and both are fixed the same way:

1. False failure. The job's actual work (aggregate the artifacts, post one comment) is unaffected by which source it checks out. The checkout just aborts before any of it runs.
2. Pwn-request exposure. This job runs from `workflow_run` with a write-scoped `GITHUB_TOKEN` and secrets. Its only use of the working tree is running `ci/scripts/pretty_aggregate.py`; artifacts and PR metadata come from the API. Checking out head_sha means running the fork author's copy of that script under a token that can write to the repo, so a malicious fork could edit the script to exfiltrate the token or push to the base.

Fix: drop the `ref` so checkout takes the default branch, i.e. the trusted base copy of the aggregation script. Legitimate PRs get the same comment; untrusted code no longer runs under the write token. I chose this over `allow-unsafe-pr-checkout: true`, which would silence the error while leaving the hole open.
