### PR TITLE
gelu: re-enable the tile_size=8192 test

### DIFF
--- a/iron/operators/gelu/test.py
+++ b/iron/operators/gelu/test.py
@@ -10,21 +10,11 @@ from iron.common.test_utils import run_test, make_channeled_unary_params
 
 
 def get_params():
-    def _marks(ext, ts):
-        marks = []
-        if ext:
-            marks.append(pytest.mark.extensive)
-        # TODO: temporary - disable tile_size=8192 for GeLU, issue #113
-        if ts == 8192:
-            marks.append(
-                pytest.mark.skip(
-                    reason="temporary: tile_size=8192 disabled for GeLU, see issue #113"
-                )
-            )
-        return marks
+    def _marks(ext):
+        return [pytest.mark.extensive] if ext else []
 
     return [
-        pytest.param(il, nac, nc, ts, marks=_marks(ext, ts))
+        pytest.param(il, nac, nc, ts, marks=_marks(ext))
         for il, nac, nc, ts, ext in make_channeled_unary_params(
             [1024, 2048, 4096, 8192], 8192, [1, 2]
         )


### PR DESCRIPTION
**Closes #113.**

---

#113 disabled this case pending the LUT alignment fix in
[mlir-aie #3045](https://github.com/Xilinx/mlir-aie/pull/3045) ("Fix alignment for look up tables"),
which has since merged.

That fix is in the `mlir_aie` version pinned here, so CI already has it:

- #3045 merged as `6032217` (2026-05-11)
- `requirements.txt` pins `mlir_aie==1.3.5.dev20+g167f34d` (`167f34d`, 2026-07-08)
- `git merge-base --is-ancestor 6032217 167f34d` -> yes

## Testing

Validated against the pinned toolchain rather than a local build: a fresh venv with
`pip install -r requirements.txt` (so `mlir_aie==1.3.5.dev20+g167f34d` and
`llvm-aie==21.0.0.2026062301+cb664e8c`, exactly what CI installs), cold JIT cache, on Strix/NPU2.

The parameter set generates exactly one `tile_size=8192` config (`input_length=8192`, 1 column,
1 channel). **160 passed** for the full `gelu` suite, 40/40 for the `8192` selection.

One caveat worth flagging: this test is marked `extensive` (`is_extensive = input_length != 2048`),
and the extensive workflows trigger on `push`/`schedule` rather than `pull_request` -- so PR CI
won't exercise it. If you'd like confirmation before merging, a `workflow_dispatch` run of
`phoenix-extensive` or `krackan-extensive` on this branch is the only pre-merge signal available.

`_marks` no longer needs the tile size, so it takes only the extensive flag.
