### PR TITLE
Update mlir-aie to v1.4.0 and migrate the operator library to its APIs

### DIFF
--- a/aie_kernels/aie2/rms_norm.cc
+++ b/aie_kernels/aie2/rms_norm.cc
@@ -38,20 +38,20 @@ void rms_norm_general(const T *restrict input,
 
     float rms = sum_sq / cols + epsilon;
     float inv_rms = invsqrt(rms);
-    // Normalize in f32 and round once/ Mirrors layer_norm.cc's accfloat path.
-    ::aie::accum<accfloat, N> inv_rms_v;
-    inv_rms_v.from_vector(::aie::broadcast<float, N>(inv_rms), 0);
+    // Peano has no f32 vector multiply for AIE2, so the f32 scale rides in a
+    // bf16 pair and is applied as two exact products accumulated in f32. A
+    // single bf16 scale would shift every element of a norm the same way.
+    T inv_rms_hi = static_cast<T>(inv_rms);
+    T inv_rms_lo = static_cast<T>(inv_rms - static_cast<float>(inv_rms_hi));
 
     for (int i = 0; i < vector_chunks; i++) {
-        ::aie::accum<accfloat, N> reg_a;
-        reg_a.from_vector(::aie::load_v<N>(input + i * N), 0);
-        reg_a = ::aie::mul(reg_a.template to_vector<float>(), inv_rms_v.template to_vector<float>());
+        ::aie::vector<T, N> reg_a = ::aie::load_v<N>(input + i * N);
+        ::aie::accum<accfloat, N> acc = ::aie::mul(reg_a, inv_rms_hi);
+        acc = ::aie::mac(acc, reg_a, inv_rms_lo);
         if (input2) {
-            ::aie::accum<accfloat, N> reg_b;
-            reg_b.from_vector(::aie::load_v<N>(input2 + i * N), 0);
-            reg_a = ::aie::mul(reg_a.template to_vector<float>(), reg_b.template to_vector<float>());
+            acc = ::aie::mul(acc.template to_vector<T>(), ::aie::load_v<N>(input2 + i * N));
         }
-        ::aie::store_v(output + i * N, reg_a.template to_vector<T>());
+        ::aie::store_v(output + i * N, acc.template to_vector<T>());
     }
 
     if (remaining > 0) {

--- a/iron/common/compilation/base.py
+++ b/iron/common/compilation/base.py
@@ -518,7 +518,6 @@ class AieccFullElfCompilationRule(AieccCompilationRule):
                 str(self.aiecc_path),
                 "-v",
                 f"-j{os.environ.get('AIECC_JOBS', '1')}",
-                "--no-compile-host",
             ]
             if self.use_chess:
                 compile_cmd += [
@@ -534,9 +533,16 @@ class AieccFullElfCompilationRule(AieccCompilationRule):
                 ]
             compile_cmd += [
                 "--expand-load-pdis",
-                "--generate-full-elf",
+                "--get-full-elf",
                 "--full-elf-name",
                 os.path.abspath(artifact.filename),
+                # Unrequested, params.txt is never written and
+                # SequenceFullELFCallable.params silently returns None. It has
+                # no name flag of its own, so --output-dir is what puts it in
+                # the project directory that property reads.
+                "--get-scratchpad-parameters",
+                "--output-dir",
+                os.path.abspath(artifact.mlir_input.filename) + ".prj",
                 *artifact.extra_flags,
                 os.path.abspath(artifact.mlir_input.filename),
             ]
@@ -573,7 +579,6 @@ class AieccXclbinInstsCompilationRule(AieccCompilationRule):
                 str(self.aiecc_path),
                 "-v",
                 f"-j{os.environ.get('AIECC_JOBS', '1')}",
-                "--no-compile-host",
             ]
             if self.use_chess:
                 compile_cmd += [
@@ -597,7 +602,7 @@ class AieccXclbinInstsCompilationRule(AieccCompilationRule):
                     0
                 ]  # TODO: this does not handle the case of multiple xclbins with different kernel names or flags from the same MLIR
                 compile_cmd += first_xclbin.extra_flags + [
-                    "--aie-generate-xclbin",
+                    "--get-xclbin",
                     "--xclbin-name=" + os.path.abspath(first_xclbin.filename),
                     "--xclbin-kernel-name=" + first_xclbin.kernel_name,
                 ]
@@ -610,10 +615,10 @@ class AieccXclbinInstsCompilationRule(AieccCompilationRule):
                 first_insts_bin = mlir_sources_to_insts[mlir_source][
                     0
                 ]  # TODO: this does not handle the case of multiple insts.bins with different flags from the same MLIR
-                if not do_compile_xclbin:
-                    compile_cmd += ["--no-compile"]
+                # Outputs are selected by --get-<name>; asking only for the insts is what
+                # "--no-compile" used to mean, so there is nothing to opt out of here.
                 compile_cmd += first_insts_bin.extra_flags + [
-                    "--aie-generate-npu-insts",
+                    "--get-npu-insts",
                     "--npu-insts-name=" + os.path.abspath(first_insts_bin.filename),
                 ]
             compile_cmd += [os.path.abspath(mlir_source.filename)]

--- a/iron/common/sequence.py
+++ b/iron/common/sequence.py
@@ -574,13 +574,16 @@ class SequenceFullELFCallable(SequenceCallable):
         The ``params.txt`` describing the runtime parameters is written by
         ``aie-lower-parameters`` into the ``<mlir>.prj`` project directory next
         to the fused MLIR source. Returns ``None`` if the sequence declared no
-        runtime parameters (in which case the file is not written).
+        runtime parameters: the file is still written, but holds a count of
+        zero and there is no ctrl scratchpad buffer object to bind to.
         """
         if self._params is not None:
             return self._params
         mlir_filename = self.op.artifacts[0].mlir_input.filename
         params_path = Path(mlir_filename + ".prj") / "params.txt"
         if not params_path.exists():
+            return None
+        if params_path.read_text().split("\n", 1)[0].strip() == "0":
             return None
         from aie.utils.hostruntime.xrtruntime.parameter_scratchpad import (
             ParameterScratchpad,

--- a/iron/operators/_trace.py
+++ b/iron/operators/_trace.py
@@ -39,13 +39,11 @@ def _default_coretile_events():
     ]
 
 
-def maybe_enable_trace(rt, trace_size, workers, coretile_events=None):
-    """Configure per-op hardware trace on ``rt`` if tracing is requested.
-
-    Call inside the ``rt.sequence(...)`` block, before ``rt.start(...)``.
+def maybe_enable_trace(prog, trace_size, workers, coretile_events=None):
+    """Configure per-op hardware trace if tracing is requested.
 
     Args:
-        rt: the ``Runtime`` being built.
+        prog: the ``Program`` being built.
         trace_size: the design's ``trace_size`` argument (may be None/0).
         workers: the design's workers; the first ``IRON_TRACE_NTILES`` are traced.
         coretile_events: override the default core-tile event set.
@@ -61,7 +59,7 @@ def maybe_enable_trace(rt, trace_size, workers, coretile_events=None):
     # meaningless (a negative slice index would silently drop the LAST worker).
     ntiles = max(0, int(os.environ.get("IRON_TRACE_NTILES", "1")))
 
-    rt.enable_trace(
+    prog.enable_trace(
         ts,
         workers=list(workers)[:ntiles],
         coretile_events=(

--- a/iron/operators/axpy/design.py
+++ b/iron/operators/axpy/design.py
@@ -4,7 +4,7 @@
 from ml_dtypes import bfloat16
 import numpy as np
 
-from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, TaskGroup, Worker
 from aie.helpers.taplib.tap import TensorAccessPattern
 from aie.iron.controlflow import range_
 from iron.operators._trace import maybe_enable_trace
@@ -84,38 +84,45 @@ def my_axpy(
     ]
 
     # Runtime operations to move data to/from the AIE-array
-    rt = Runtime()
-    with rt.sequence(tensor_ty, tensor_ty, tensor_ty) as (A, B, C):
-        maybe_enable_trace(rt, trace_size, my_workers)
-        rt.start(*my_workers)
-
+    def sequence(A, B, C, in1_prods, in2_prods, out_conses):
         # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
-        tg = rt.task_group()
+        tg = TaskGroup()
 
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
-            rt.fill(
-                of_in1s[i].prod(),
+            in1_prods[i].fill(
                 A,
                 taps[i],
-                task_group=tg,
+                group=tg,
             )
-            rt.fill(
-                of_in2s[i].prod(),
+            in2_prods[i].fill(
                 B,
                 taps[i],
-                task_group=tg,
+                group=tg,
             )
         # Drain the output objectFIFOs with data
         for i in range(num_columns):
-            rt.drain(
-                of_outs[i].cons(),
+            out_conses[i].drain(
                 C,
                 taps[i],
                 wait=True,  # wait for the transfer to complete and data to be available
-                task_group=tg,
+                group=tg,
             )
-        rt.finish_task_group(tg)
+        tg.finish()
+
+    rt = Runtime(
+        sequence,
+        [
+            tensor_ty,
+            tensor_ty,
+            tensor_ty,
+            [of_in1s[i].prod() for i in range(num_columns)],
+            [of_in2s[i].prod() for i in range(num_columns)],
+            [of_outs[i].cons() for i in range(num_columns)],
+        ],
+    )
 
     # Place program components (assign them resources on the device) and generate an MLIR module
-    return Program(dev, rt).resolve_program()
+    prog = Program(dev, rt, workers=my_workers)
+    maybe_enable_trace(prog, trace_size, my_workers)
+    return prog.resolve_program()

--- a/iron/operators/binary_elementwise_design.py
+++ b/iron/operators/binary_elementwise_design.py
@@ -4,7 +4,7 @@
 from ml_dtypes import bfloat16
 import numpy as np
 
-from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, TaskGroup, Worker
 from aie.helpers.taplib.tap import TensorAccessPattern
 from aie.iron.controlflow import range_
 from iron.operators._trace import maybe_enable_trace
@@ -83,37 +83,44 @@ def binary_elementwise_design(
     ]
 
     # Runtime operations to move data to/from the AIE-array
-    rt = Runtime()
-    with rt.sequence(tensor_ty, tensor_ty, tensor_ty) as (A, B, C):
-        maybe_enable_trace(rt, trace_size, my_workers)
-        rt.start(*my_workers)
-
-        tg = rt.task_group()
+    def sequence(A, B, C, in1_prods, in2_prods, out_conses):
+        tg = TaskGroup()
 
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
-            rt.fill(
-                of_in1s[i].prod(),
+            in1_prods[i].fill(
                 A,
                 taps[i],
-                task_group=tg,
+                group=tg,
             )
-            rt.fill(
-                of_in2s[i].prod(),
+            in2_prods[i].fill(
                 B,
                 taps[i],
-                task_group=tg,
+                group=tg,
             )
         # Drain the output objectFIFOs with data
         for i in range(num_columns):
-            rt.drain(
-                of_outs[i].cons(),
+            out_conses[i].drain(
                 C,
                 taps[i],
                 wait=True,
-                task_group=tg,
+                group=tg,
             )
-        rt.finish_task_group(tg)
+        tg.finish()
+
+    rt = Runtime(
+        sequence,
+        [
+            tensor_ty,
+            tensor_ty,
+            tensor_ty,
+            [of_in1s[i].prod() for i in range(num_columns)],
+            [of_in2s[i].prod() for i in range(num_columns)],
+            [of_outs[i].cons() for i in range(num_columns)],
+        ],
+    )
 
     # Place program components and generate an MLIR module
-    return Program(dev, rt).resolve_program()
+    prog = Program(dev, rt, workers=my_workers)
+    maybe_enable_trace(prog, trace_size, my_workers)
+    return prog.resolve_program()

--- a/iron/operators/channeled_unary_design.py
+++ b/iron/operators/channeled_unary_design.py
@@ -4,7 +4,7 @@
 from ml_dtypes import bfloat16
 import numpy as np
 
-from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, TaskGroup, Worker
 from aie.helpers.taplib.tap import TensorAccessPattern
 from aie.iron.controlflow import range_
 from iron.operators._trace import maybe_enable_trace
@@ -97,33 +97,39 @@ def channeled_unary_design(
     ]
 
     # Runtime operations to move data to/from the AIE-array
-    rt = Runtime()
-    with rt.sequence(transfer_type, transfer_type) as (a_in, b_out):
-        maybe_enable_trace(rt, trace_size, my_workers)
-        rt.start(*my_workers)
-
-        tg = rt.task_group()
+    def sequence(a_in, b_out, in_prods, out_conses):
+        tg = TaskGroup()
 
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
-                rt.fill(
-                    of_ins[i * num_channels + j].prod(),
+                in_prods[i * num_channels + j].fill(
                     a_in,
                     taps[i * num_channels + j],
-                    task_group=tg,
+                    group=tg,
                 )
         # Drain the output objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
-                rt.drain(
-                    of_outs[i * num_channels + j].cons(),
+                out_conses[i * num_channels + j].drain(
                     b_out,
                     taps[i * num_channels + j],
                     wait=True,
-                    task_group=tg,
+                    group=tg,
                 )
-        rt.finish_task_group(tg)
+        tg.finish()
+
+    rt = Runtime(
+        sequence,
+        [
+            transfer_type,
+            transfer_type,
+            [of.prod() for of in of_ins],
+            [of.cons() for of in of_outs],
+        ],
+    )
 
     # Place components and generate an MLIR module
-    return Program(dev, rt).resolve_program()
+    prog = Program(dev, rt, workers=my_workers)
+    maybe_enable_trace(prog, trace_size, my_workers)
+    return prog.resolve_program()

--- a/iron/operators/dequant/design.py
+++ b/iron/operators/dequant/design.py
@@ -4,7 +4,7 @@
 from ml_dtypes import bfloat16
 import numpy as np
 
-from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, TaskGroup, Worker
 from aie.helpers.taplib.tap import TensorAccessPattern
 from aie.iron.controlflow import range_
 
@@ -118,35 +118,41 @@ def my_dequant_kernel(
     ]
 
     # Runtime operations to move data to/from the AIE-array
-    rt = Runtime()
-    with rt.sequence(in_tensor_ty, out_tensor_ty) as (A, C):
-        if enable_trace:
-            rt.enable_trace(trace_size)
-        rt.start(*my_workers)
+    def sequence(A, C, of_in1s_prods, of_outs_conss):
 
         # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
-        tg = rt.task_group()
+        tg = TaskGroup()
 
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
-                rt.fill(
-                    of_in1s[i * num_channels + j].prod(),
+                of_in1s_prods[i * num_channels + j].fill(
                     A,
                     taps_in[i * num_channels + j],
-                    task_group=tg,
+                    group=tg,
                 )
         # Drain the output objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
-                rt.drain(
-                    of_outs[i * num_channels + j].cons(),
+                of_outs_conss[i * num_channels + j].drain(
                     C,
                     taps_out[i * num_channels + j],
                     wait=True,  # wait for the transfer to complete and data to be available
-                    task_group=tg,
+                    group=tg,
                 )
-        rt.finish_task_group(tg)
+        tg.finish()
 
+    rt = Runtime(
+        sequence,
+        [
+            in_tensor_ty,
+            out_tensor_ty,
+            [of.prod() for of in of_in1s],
+            [of.cons() for of in of_outs],
+        ],
+    )
     # Place program components (assign them resources on the device) and generate an MLIR module
-    return Program(dev, rt).resolve_program()
+    prog = Program(dev, rt, workers=my_workers)
+    if enable_trace:
+        prog.enable_trace(trace_size)
+    return prog.resolve_program()

--- a/iron/operators/gemm/design.py
+++ b/iron/operators/gemm/design.py
@@ -14,6 +14,7 @@ from aie.iron import (
     Program,
     Buffer,
     Runtime,
+    TaskGroup,
     Worker,
     WorkerRuntimeBarrier,
     str_to_dtype,
@@ -551,28 +552,21 @@ def my_matmul(
         )
 
     # Runtime operations to move data to/from the AIE-array
-    rt = Runtime()
-    with rt.sequence(A_ty, B_ty, C_ty) as (A, B, C):
-        maybe_enable_trace(rt, trace_size, workers)
-        rt.start(*workers)
-
+    def sequence(A, B, C, A_prods, B_prods, C_conses):
         # Set runtime parameters
-        def set_rtps(*args):
-            for row, rtps_row in enumerate(args):
-                for col, rtp_row_col in enumerate(rtps_row):
-                    rtp_row_col[0] = K_div_k
-                    rtp_row_col[1] = n_c_row_tiles_per_core * n_c_col_tiles_per_core
-
-        rt.inline_ops(set_rtps, rtps)
+        for rtps_row in rtps:
+            for rtp_row_col in rtps_row:
+                rtp_row_col[0] = K_div_k
+                rtp_row_col[1] = n_c_row_tiles_per_core * n_c_col_tiles_per_core
 
         # Set the barriers to 1 to allow the worker to read the
         # runtime parameters and start the computation
         for row in range(n_aie_rows):
             for col in range(n_aie_cols):
-                rt.set_barrier(workerBarriers[row][col], 1)
+                workerBarriers[row][col].set(1)
 
         # Task groups will be used to determine when to sync/await/free DMA runtime ops
-        tg = rt.task_group()
+        tg = TaskGroup()
         for tb in range(ceildiv(n_c_row_tiles_per_core, tb_max_n_rows)):
             for pingpong in [0, 1]:
                 row_base = tb * tb_max_n_rows + pingpong * tb_max_n_rows // 2
@@ -630,13 +624,11 @@ def my_matmul(
                         # This line does not change MLIR output at all - it's just for recording data movement
                         C_taps.append(C_tile)
 
-                        rt.drain(
-                            C_l2l3_fifos[col].cons(),
+                        C_conses[col].drain(
                             C,
                             tap=C_tile,
                             wait=True,
-                            task_group=tg,
-                            tile=Tile(col, 0),
+                            group=tg,
                         )
 
                     for tile_row in range(current_tb_n_rows):
@@ -685,13 +677,11 @@ def my_matmul(
                                 sizes=C_sizes,
                                 strides=C_strides,
                             )
-                            rt.drain(
-                                C_l2l3_fifos[col].cons(),
+                            C_conses[col].drain(
                                 C,
                                 tap=C_tile,
                                 wait=True,
-                                task_group=tg,
-                                tile=Tile(col, 0),
+                                group=tg,
                             )
                             # This line does not change MLIR output at all - it's just for recording data movement
                             C_taps.append(C_tile)
@@ -720,14 +710,10 @@ def my_matmul(
 
                         # always equal to n_aie_rows since we have n_aie_rows row tiles for matrix A
                         if col < n_aie_rows:
-                            rt.fill(
-                                A_l3l2_fifos[col].prod(),
+                            A_prods[col].fill(
                                 A,
                                 tap=A_tiles[tile_offset],
-                                task_group=tg,
-                                tile=Tile(
-                                    2 * col if n_aie_cols == 8 else col, 0
-                                ),  # alternate columns in full 4x8 NPU2 case
+                                group=tg,
                             )
                         # Use the calculated sizes/strides/offsets to record the data movement
                         # caused by the above call to npu_dma_memcpy_nd.
@@ -751,21 +737,45 @@ def my_matmul(
                         #     |0011    0011    |
                         #     |0011    0011    |
                         #      ----------------
-                        rt.fill(
-                            B_l3l2_fifos[col].prod(),
+                        B_prods[col].fill(
                             B,
                             tap=B_tiles[col],
-                            task_group=tg,
-                            tile=Tile(col, 0),
+                            group=tg,
                         )
 
                         # These lines do not change MLIR output at all - they are just for recording data movement
                         A_taps.append(A_tiles[tile_offset])
                         B_taps.append(B_tiles[col])
                 if tb > 0 or (tb == 0 and pingpong > 0):
-                    rt.finish_task_group(tg)
-                    tg = rt.task_group()
-        rt.finish_task_group(tg)
+                    tg.finish()
+                    tg = TaskGroup()
+        tg.finish()
+
+    rt = Runtime(
+        sequence,
+        [
+            A_ty,
+            B_ty,
+            C_ty,
+            # The shim tile that used to be named per-transfer is now a property
+            # of the handle, so it is bound here instead.
+            [
+                f.prod(tile=Tile(2 * c if n_aie_cols == 8 else c, 0))
+                for c, f in enumerate(A_l3l2_fifos)
+            ],
+            [f.prod(tile=Tile(c, 0)) for c, f in enumerate(B_l3l2_fifos)],
+            [f.cons(tile=Tile(c, 0)) for c, f in enumerate(C_l2l3_fifos)],
+        ],
+    )
+
+    # Create the program from the device type and runtime
+    my_program = Program(dev_ty, rt, workers=workers)
+    maybe_enable_trace(my_program, trace_size, workers)
+
+    # Place components (assign them resources on the device) and generate an MLIR module.
+    # This is what runs the sequence body, so it must happen before the taps it
+    # records are read.
+    module = my_program.resolve_program()
 
     if generate_taps:
         # If generate taps is true, return a representation of tensor access patterns
@@ -776,11 +786,6 @@ def my_matmul(
             TensorAccessSequence.from_taps(C_taps),
         )
 
-    # Create the program from the device type and runtime
-    my_program = Program(dev_ty, rt)
-
-    # Place components (assign them resources on the device) and generate an MLIR module
-    module = my_program.resolve_program()
     return module
 
 

--- a/iron/operators/gemv/design.py
+++ b/iron/operators/gemv/design.py
@@ -8,7 +8,7 @@ import aie.dialects.index as index
 from aie.dialects.aie import T
 from aie.helpers.dialects.scf import _for as range_
 from aie.helpers.taplib import TensorAccessPattern
-from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, TaskGroup, Worker
 
 """
 Matrix-vector design
@@ -250,33 +250,41 @@ def my_matvec(
             for col in range(cols)
         ]
 
-    rt = Runtime()
-    with rt.sequence(L3_A_ty, L3_B_ty, L3_C_ty) as (A, B, C):
-        rt.start(*workers)
-        tg_b = rt.task_group()
+    def sequence(A, B, C, B_L3L1_fifos_prods, A_L3L1_fifos_prods, C_L1L3_fifos_conss):
+        tg_b = TaskGroup()
         for col in range(cols):
             # Simple linear transfer of B, includes all batches in sequence
-            rt.fill(B_L3L1_fifos[col].prod(), B, B_tap, task_group=tg_b)
+            B_L3L1_fifos_prods[col].fill(B, B_tap, group=tg_b)
         # Coalesced: one iterated BD per column covers all batches (num_waits==1, a
         # single drain wait for the whole column). Fallback (incl. num_batches==1): the
         # stock per-batch unroll (num_waits==num_batches, one wait per batch). The fills
         # and drains are otherwise identical; only the TAP and the wait count differ.
         num_waits = 1 if coalesce else num_batches
         for w in range(num_waits):
-            tg_ac = rt.task_group()
+            tg_ac = TaskGroup()
             for col in range(cols):
                 a_tap = A_taps_coalesced[col] if coalesce else A_taps[col][w]
-                rt.fill(A_L3L1_fifos[col].prod(), A, a_tap, task_group=tg_ac)
+                A_L3L1_fifos_prods[col].fill(A, a_tap, group=tg_ac)
             for col in range(cols):
                 c_tap = C_taps_coalesced[col] if coalesce else C_taps[col][w]
-                rt.drain(
-                    C_L1L3_fifos[col].cons(),
+                C_L1L3_fifos_conss[col].drain(
                     C,
                     c_tap,
-                    task_group=tg_ac,
+                    group=tg_ac,
                     wait=True,
                 )
-            rt.finish_task_group(tg_ac)
-        rt.finish_task_group(tg_b)
+            tg_ac.finish()
+        tg_b.finish()
 
-    return Program(dev, rt).resolve_program()
+    rt = Runtime(
+        sequence,
+        [
+            L3_A_ty,
+            L3_B_ty,
+            L3_C_ty,
+            [of.prod() for of in B_L3L1_fifos],
+            [of.prod() for of in A_L3L1_fifos],
+            [of.cons() for of in C_L1L3_fifos],
+        ],
+    )
+    return Program(dev, rt, workers=workers).resolve_program()

--- a/iron/operators/leaky_relu/design.py
+++ b/iron/operators/leaky_relu/design.py
@@ -4,7 +4,7 @@
 from ml_dtypes import bfloat16
 import numpy as np
 
-from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, TaskGroup, Worker
 from aie.helpers.taplib.tap import TensorAccessPattern
 from aie.iron.controlflow import range_
 from iron.operators._trace import maybe_enable_trace
@@ -93,34 +93,40 @@ def my_leaky_relu(
     ]
 
     # Runtime operations to move data to/from the AIE-array
-    rt = Runtime()
-    with rt.sequence(transfer_type, transfer_type) as (a_in, b_out):
-        maybe_enable_trace(rt, trace_size, my_workers)
-        rt.start(*my_workers)
+    def sequence(a_in, b_out, of_ins_prods, of_outs_conss):
 
         # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
-        tg = rt.task_group()
+        tg = TaskGroup()
 
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
-                rt.fill(
-                    of_ins[i * num_channels + j].prod(),
+                of_ins_prods[i * num_channels + j].fill(
                     a_in,
                     taps[i * num_channels + j],
-                    task_group=tg,
+                    group=tg,
                 )
         # Drain the output objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
-                rt.drain(
-                    of_outs[i * num_channels + j].cons(),
+                of_outs_conss[i * num_channels + j].drain(
                     b_out,
                     taps[i * num_channels + j],
                     wait=True,  # wait for the transfer to complete and data to be available
-                    task_group=tg,
+                    group=tg,
                 )
-        rt.finish_task_group(tg)
+        tg.finish()
 
+    rt = Runtime(
+        sequence,
+        [
+            transfer_type,
+            transfer_type,
+            [of.prod() for of in of_ins],
+            [of.cons() for of in of_outs],
+        ],
+    )
     # Place components (assign them resources on the device) and generate an MLIR module
-    return Program(dev, rt).resolve_program()
+    prog = Program(dev, rt, workers=my_workers)
+    maybe_enable_trace(prog, trace_size, my_workers)
+    return prog.resolve_program()

--- a/iron/operators/mem_copy/design.py
+++ b/iron/operators/mem_copy/design.py
@@ -9,6 +9,7 @@ import numpy as np
 import math
 
 from aie.iron import (
+    TaskGroup,
     Kernel,
     ObjectFifo,
     Program,
@@ -242,13 +243,7 @@ def my_mem_copy(
     # --------------------------------------------------------------------------
 
     # Runtime operations to move data to/from the AIE-array
-    rt = Runtime()
-    with rt.sequence(transfer_type, transfer_type) as (a_in, b_out):
-        # Start the workers if not bypass
-        if not bypass:
-            maybe_enable_trace(rt, trace_size, my_workers)
-            rt.start(*my_workers)
-
+    def sequence(a_in, b_out, of_ins_prods, of_outs_conss):
         # Calculate how much of workload can be partitioned evenly and what's remaining
         minimum_work_size = (
             line_size * num_cores
@@ -263,20 +258,19 @@ def my_mem_copy(
                 size, num_cores, line_size, whole_partition_size
             )
 
-            tg_out = rt.task_group()  # Use taskgroup for parallel drain tasks
+            tg_out = TaskGroup()  # Use taskgroup for parallel drain tasks
             # Fill the input objectFIFOs with data
             for i in range(num_cores):
-                rt.fill(of_ins[i].prod(), a_in, taps[i], task_group=tg_out)
+                of_ins_prods[i].fill(a_in, taps[i], group=tg_out)
             # Drain the output objectFIFOs with data
             for i in range(num_cores):
-                rt.drain(
-                    of_outs[i].cons(),
+                of_outs_conss[i].drain(
                     b_out,
                     taps[i],
                     wait=True,  # wait for the transfer to complete and data to be available
-                    task_group=tg_out,
+                    group=tg_out,
                 )
-            rt.finish_task_group(tg_out)
+            tg_out.finish()
 
         # Runtime for the part of the workload partially partitionable to the cores utilized
         if partial_work_size > 0:
@@ -310,46 +304,42 @@ def my_mem_copy(
                     and partial_config.partial_tap is not None
                 ):
                     # Fill the last objfifo with padding+real data
-                    tg_out = rt.task_group()
+                    tg_out = TaskGroup()
                     tg_count = 0
                     for padding_tap_repeat, padding_tap in zip(
                         partial_config.padding_tap_repeats, partial_config.padding_taps
                     ):
                         for _ in range(padding_tap_repeat):
                             if tg_count % TASK_GROUP_SIZE == 0:
-                                rt.fill(
-                                    of_ins[objfifo_idx].prod(),
+                                of_ins_prods[objfifo_idx].fill(
                                     a_in,
                                     padding_tap,
                                     wait=True,
-                                    task_group=tg_out,
+                                    group=tg_out,
                                 )
-                                rt.finish_task_group(tg_out)
-                                tg_out = rt.task_group()
+                                tg_out.finish()
+                                tg_out = TaskGroup()
                             else:
-                                rt.fill(
-                                    of_ins[objfifo_idx].prod(),
+                                of_ins_prods[objfifo_idx].fill(
                                     a_in,
                                     padding_tap,
-                                    task_group=tg_out,
+                                    group=tg_out,
                                 )
                             tg_count += 1
                     if tg_count % TASK_GROUP_SIZE == 0:
-                        rt.fill(
-                            of_ins[objfifo_idx].prod(),
+                        of_ins_prods[objfifo_idx].fill(
                             a_in,
                             partial_config.partial_tap,
                             wait=True,
-                            task_group=tg_out,
+                            group=tg_out,
                         )
-                        rt.finish_task_group(tg_out)
-                        tg_out = rt.task_group()
+                        tg_out.finish()
+                        tg_out = TaskGroup()
                     else:
-                        rt.fill(
-                            of_ins[objfifo_idx].prod(),
+                        of_ins_prods[objfifo_idx].fill(
                             a_in,
                             partial_config.partial_tap,
-                            task_group=tg_out,
+                            group=tg_out,
                         )
                     tg_count += 1
                     # Drain the last objfifo with padding+real data
@@ -358,53 +348,62 @@ def my_mem_copy(
                     ):
                         for _ in range(padding_tap_repeat):
                             if tg_count % TASK_GROUP_SIZE == 0:
-                                rt.drain(
-                                    of_outs[objfifo_idx].cons(),
+                                of_outs_conss[objfifo_idx].drain(
                                     b_out,
                                     padding_tap,
                                     wait=True,
-                                    task_group=tg_out,
+                                    group=tg_out,
                                 )
-                                rt.finish_task_group(tg_out)
-                                tg_out = rt.task_group()
+                                tg_out.finish()
+                                tg_out = TaskGroup()
                             else:
-                                rt.drain(
-                                    of_outs[objfifo_idx].cons(),
+                                of_outs_conss[objfifo_idx].drain(
                                     b_out,
                                     padding_tap,
-                                    task_group=tg_out,
+                                    group=tg_out,
                                 )
                             tg_count += 1
-                    rt.drain(
-                        of_outs[objfifo_idx].cons(),
+                    of_outs_conss[objfifo_idx].drain(
                         b_out,
                         partial_config.partial_tap,
                         wait=True,
-                        task_group=tg_out,
+                        group=tg_out,
                     )
-                    rt.finish_task_group(tg_out)
+                    tg_out.finish()
                     objfifo_idx += 1
                 else:
-                    tg_out = rt.task_group()  # Use taskgroup for parallel drain tasks
+                    tg_out = TaskGroup()  # Use taskgroup for parallel drain tasks
                     for j in range(partial_config.num_cores_with_full_tiles):
                         # Fill the input objectFIFOs with valid data
-                        rt.fill(
-                            of_ins[objfifo_idx + j].prod(),
+                        of_ins_prods[objfifo_idx + j].fill(
                             a_in,
                             partial_config.full_taps[j],
-                            task_group=tg_out,
+                            group=tg_out,
                         )
                     for j in range(partial_config.num_cores_with_full_tiles):
                         # Drain the output objectFIFOs with valid data
-                        rt.drain(
-                            of_outs[objfifo_idx + j].cons(),
+                        of_outs_conss[objfifo_idx + j].drain(
                             b_out,
                             partial_config.full_taps[j],
                             wait=True,
-                            task_group=tg_out,
+                            group=tg_out,
                         )
-                    rt.finish_task_group(tg_out)
+                    tg_out.finish()
                     objfifo_idx += partial_config.num_cores_with_full_tiles
 
+    rt = Runtime(
+        sequence,
+        [
+            transfer_type,
+            transfer_type,
+            [of.prod() for of in of_ins],
+            [of.cons() for of in of_outs],
+        ],
+    )
     # Place components (assign them resources on the device) and generate an MLIR module
-    return Program(dev, rt).resolve_program()
+    # bypass means the DMAs run without any compute worker, as `rt.start` was
+    # previously guarded by the same condition.
+    prog = Program(dev, rt, workers=None if bypass else my_workers)
+    if not bypass:
+        maybe_enable_trace(prog, trace_size, my_workers)
+    return prog.resolve_program()

--- a/iron/operators/mha/design.py
+++ b/iron/operators/mha/design.py
@@ -15,6 +15,7 @@ from aie.iron import (
     ObjectFifo,
     Program,
     Runtime,
+    TaskGroup,
     Worker,
     Buffer,
     WorkerRuntimeBarrier,
@@ -775,31 +776,27 @@ def fused_mha(
         # print_tap_seq_info(O_tiles, "O")
 
     # Runtime operations to move data to/from the AIE-array
-    rt = Runtime()
-    with rt.sequence(Q_ty, KV_ty, KV_ty, Q_ty) as (Q, K, V, O):
+    # The shim tile that used to be named per-transfer is now a property of the
+    # handle, so the handles are bound up front and passed into the sequence.
+    inQ_h = inQ.prod(tile=Tile(col=4, row=0))
+    inQ2_h = inQ2.prod(tile=Tile(col=4, row=0)) if number_of_pipelines > 6 else None
+    inK_h = inK.prod(tile=Tile(col=5, row=0))
+    inV_h = inV.prod(tile=Tile(col=6, row=0))
+    memO_h = memO.cons(tile=Tile(col=7, row=0))
+    memO2_h = memO2.cons(tile=Tile(col=7, row=0)) if number_of_pipelines > 6 else None
 
-        def set_mha_rtps():
-            for j in range(3):
-                for i in range(number_of_pipelines):
-                    mha_rtps_list[j][i][0] = num_q_block_per_pipeline
-                    mha_rtps_list[j][i][1] = num_kv_blocks
-                    mha_rtps_list[j][i][2] = S_q_eff
-                    mha_rtps_list[j][i][3] = S_kv_eff
-
-        rt.inline_ops(set_mha_rtps, ())
+    def sequence(Q, K, V, O, inQ_h, inQ2_h, inK_h, inV_h, memO_h, memO2_h):
+        # The body is eager now, so the RTP writes are a plain loop (was inline_ops).
+        for j in range(3):
+            for i in range(number_of_pipelines):
+                mha_rtps_list[j][i][0] = num_q_block_per_pipeline
+                mha_rtps_list[j][i][1] = num_kv_blocks
+                mha_rtps_list[j][i][2] = S_q_eff
+                mha_rtps_list[j][i][3] = S_kv_eff
 
         for j in range(3):
             for i in range(number_of_pipelines):
-                rt.set_barrier(worker_barrier_list[j][i], 1)
-
-        maybe_enable_trace(
-            rt, trace_size, matmul_workers + softmax_workers + matmul_pv_workers
-        )
-
-        for i in range(number_of_pipelines):
-            rt.start(matmul_workers[i])
-            rt.start(softmax_workers[i])
-            rt.start(matmul_pv_workers[i])
+                worker_barrier_list[j][i].set(1)
 
         for head_idx in range(heads):
 
@@ -808,67 +805,54 @@ def fused_mha(
             for q_block_idx in range(num_q_block_per_pipeline):
 
                 # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
-                tg = rt.task_group()
+                tg = TaskGroup()
 
                 if number_of_pipelines > 6:
-                    rt.fill(
-                        inQ.prod(),
+                    inQ_h.fill(
                         Q,
                         tap=Q_tiles[
                             2 * head_idx * num_q_block_per_pipeline + q_block_idx * 2
                         ],
-                        tile=Tile(col=4, row=0),
-                        task_group=tg,
+                        group=tg,
                     )
-                    rt.fill(
-                        inQ2.prod(),
+                    inQ2_h.fill(
                         Q,
                         tap=Q_tiles[
                             2 * head_idx * num_q_block_per_pipeline
                             + q_block_idx * 2
                             + 1
                         ],
-                        tile=Tile(col=4, row=0),
-                        task_group=tg,
+                        group=tg,
                     )
                 else:
-                    rt.fill(
-                        inQ.prod(),
+                    inQ_h.fill(
                         Q,
                         tap=Q_tiles[head_idx * num_q_block_per_pipeline + q_block_idx],
-                        tile=Tile(col=4, row=0),
-                        task_group=tg,
+                        group=tg,
                     )
 
                 # Thow on bd containing the full K and V in the object fifo, then does it transfer cunks of inKV size at the time?
-                rt.fill(
-                    inK.prod(),
+                inK_h.fill(
                     K,
                     tap=K_tiles[kv_head_idx],
-                    tile=Tile(col=5, row=0),
-                    task_group=tg,
+                    group=tg,
                 )
-                rt.fill(
-                    inV.prod(),
+                inV_h.fill(
                     V,
                     tap=V_tiles[kv_head_idx],
-                    tile=Tile(col=6, row=0),
-                    task_group=tg,
+                    group=tg,
                 )
 
                 if number_of_pipelines > 6:
-                    rt.drain(
-                        memO.cons(),
+                    memO_h.drain(
                         O,
                         tap=O_tiles[
                             2 * head_idx * num_q_block_per_pipeline + q_block_idx * 2
                         ],
                         wait=True,
-                        tile=Tile(col=7, row=0),
-                        task_group=tg,
+                        group=tg,
                     )
-                    rt.drain(
-                        memO2.cons(),
+                    memO2_h.drain(
                         O,
                         tap=O_tiles[
                             2 * head_idx * num_q_block_per_pipeline
@@ -876,24 +860,31 @@ def fused_mha(
                             + 1
                         ],
                         wait=True,
-                        tile=Tile(col=7, row=0),
-                        task_group=tg,
+                        group=tg,
                     )
                 else:
-                    rt.drain(
-                        memO.cons(),
+                    memO_h.drain(
                         O,
                         tap=O_tiles[head_idx * num_q_block_per_pipeline + q_block_idx],
                         wait=True,
-                        tile=Tile(col=7, row=0),
-                        task_group=tg,
+                        group=tg,
                     )
 
-                rt.finish_task_group(tg)
+                tg.finish()
+
+    rt = Runtime(
+        sequence,
+        [Q_ty, KV_ty, KV_ty, Q_ty, inQ_h, inQ2_h, inK_h, inV_h, memO_h, memO2_h],
+    )
 
     # Create the program from the device type and runtime
     dev_ty = NPU2()
-    my_program = Program(dev_ty, rt)
+    my_program = Program(
+        dev_ty, rt, workers=matmul_workers + softmax_workers + matmul_pv_workers
+    )
+    maybe_enable_trace(
+        my_program, trace_size, matmul_workers + softmax_workers + matmul_pv_workers
+    )
 
     # Place components (assign them resources on the device) and generate an MLIR module
     module = my_program.resolve_program()

--- a/iron/operators/repeat/design.py
+++ b/iron/operators/repeat/design.py
@@ -8,7 +8,7 @@ Repeat interleave
 import numpy as np
 
 from aie.dialects.aiex import TensorAccessPattern
-from aie.iron import ObjectFifo, Program, Runtime
+from aie.iron import ObjectFifo, Program, Runtime, TaskGroup
 
 
 def repeat(dev, dtype, rows, cols, repeat, transfer_size=None):
@@ -61,11 +61,19 @@ def repeat(dev, dtype, rows, cols, repeat, transfer_size=None):
     fifo_in = ObjectFifo(transfer_ty, name="fifo_in", depth=2)
     fifo_out = fifo_in.cons().forward(name="fifo_out", depth=2)
 
-    rt = Runtime()
-    with rt.sequence(inp_ty, out_ty) as (inp, out):
-        tg = rt.task_group()
-        rt.fill(fifo_in.prod(), inp, input_tap, task_group=tg)
-        rt.drain(fifo_out.cons(), out, output_tap, task_group=tg, wait=True)
-        rt.finish_task_group(tg)
+    def sequence(inp, out, fifo_in_prod, fifo_out_cons):
+        tg = TaskGroup()
+        fifo_in_prod.fill(inp, input_tap, group=tg)
+        fifo_out_cons.drain(out, output_tap, group=tg, wait=True)
+        tg.finish()
 
+    rt = Runtime(
+        sequence,
+        [
+            inp_ty,
+            out_ty,
+            fifo_in.prod(),
+            fifo_out.cons(),
+        ],
+    )
     return Program(dev, rt).resolve_program()

--- a/iron/operators/rms_norm/design.py
+++ b/iron/operators/rms_norm/design.py
@@ -4,7 +4,7 @@
 from ml_dtypes import bfloat16
 import numpy as np
 
-from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, TaskGroup, Worker
 from aie.iron.device import NPU1, NPU2
 from aie.helpers.taplib.tap import TensorAccessPattern
 from aie.iron.controlflow import range_
@@ -94,33 +94,38 @@ def my_rms_norm(
     ]
 
     # Runtime operations to move data to/from the AIE-array
-    rt = Runtime()
-    with rt.sequence(tensor_ty, tensor_ty) as (A, C):
-        rt.start(*my_workers)
+    def sequence(A, C, of_in1s_prods, of_outs_conss):
 
         # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
-        tg = rt.task_group()
+        tg = TaskGroup()
 
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
-                rt.fill(
-                    of_in1s[i * num_channels + j].prod(),
+                of_in1s_prods[i * num_channels + j].fill(
                     A,
                     taps[i * num_channels + j],
-                    task_group=tg,
+                    group=tg,
                 )
         # Drain the output objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
-                rt.drain(
-                    of_outs[i * num_channels + j].cons(),
+                of_outs_conss[i * num_channels + j].drain(
                     C,
                     taps[i * num_channels + j],
                     wait=True,  # wait for the transfer to complete and data to be available
-                    task_group=tg,
+                    group=tg,
                 )
-        rt.finish_task_group(tg)
+        tg.finish()
 
+    rt = Runtime(
+        sequence,
+        [
+            tensor_ty,
+            tensor_ty,
+            [of.prod() for of in of_in1s],
+            [of.cons() for of in of_outs],
+        ],
+    )
     # Place program components (assign them resources on the device) and generate an MLIR module
-    return Program(dev, rt).resolve_program()
+    return Program(dev, rt, workers=my_workers).resolve_program()

--- a/iron/operators/rms_norm/design_weighted.py
+++ b/iron/operators/rms_norm/design_weighted.py
@@ -4,7 +4,7 @@
 from ml_dtypes import bfloat16
 import numpy as np
 
-from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, TaskGroup, Worker
 from aie.iron.device import NPU1, NPU2
 from aie.helpers.taplib.tap import TensorAccessPattern
 from aie.iron.controlflow import range_
@@ -140,42 +140,48 @@ def my_weighted_rms_norm(
     ]
 
     # Runtime operations to move data to/from the AIE-array
-    rt = Runtime()
-    with rt.sequence(tensor_ty, weights_ty, tensor_ty) as (A, B, C):
-        rt.start(*my_workers)
+    def sequence(A, B, C, of_in1s_prods, of_in2s_prods, of_out2s_conss):
 
         # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
-        tg = rt.task_group()
+        tg = TaskGroup()
 
         # Fill the input objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
                 idx = i * num_channels + j
-                rt.fill(
-                    of_in1s[idx].prod(),
+                of_in1s_prods[idx].fill(
                     A,
                     taps[idx],
-                    task_group=tg,
+                    group=tg,
                 )
         # Fill weights (one per channel)
         for j in range(num_channels):
-            rt.fill(
-                of_in2s[j].prod(),
+            of_in2s_prods[j].fill(
                 B,
-                task_group=tg,
+                group=tg,
             )
         # Drain the output objectFIFOs with data
         for i in range(num_columns):
             for j in range(num_channels):
                 idx = i * num_channels + j
-                rt.drain(
-                    of_out2s[idx].cons(),
+                of_out2s_conss[idx].drain(
                     C,
                     taps[idx],
                     wait=True,
-                    task_group=tg,
+                    group=tg,
                 )
-        rt.finish_task_group(tg)
+        tg.finish()
 
+    rt = Runtime(
+        sequence,
+        [
+            tensor_ty,
+            weights_ty,
+            tensor_ty,
+            [of.prod() for of in of_in1s],
+            [of.prod() for of in of_in2s],
+            [of.cons() for of in of_out2s],
+        ],
+    )
     # Place program components (assign them resources on the device) and generate an MLIR module
-    return Program(dev, rt).resolve_program()
+    return Program(dev, rt, workers=my_workers).resolve_program()

--- a/iron/operators/rope/design.py
+++ b/iron/operators/rope/design.py
@@ -17,7 +17,7 @@ Another interpretation of the input tensor is (rows / num_heads, num_heads, cols
 
 import numpy as np
 
-from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, TaskGroup, Worker
 from aie.iron.device import NPU1, NPU2
 from aie.helpers.taplib.tap import TensorAccessPattern
 from aie.helpers.dialects.scf import _for as range_
@@ -128,38 +128,45 @@ def rope(
     ]
 
     # Runtime operations to move data to/from the AIE-array
-    rt = Runtime()
-    with rt.sequence(tensor_ty, angle_ty, tensor_ty) as (A, B, C):
-        maybe_enable_trace(rt, trace_size, my_workers)
-        rt.start(*my_workers)
+    def sequence(A, B, C, of_in_prods, of_lut_prods, of_out_conss):
 
         # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
-        tg = rt.task_group()
+        tg = TaskGroup()
 
         # Fill the input objectFIFOs with data
         for i in range(num_aie_columns):
-            rt.fill(
-                of_in[i].prod(),
+            of_in_prods[i].fill(
                 A,
                 tensor_taps[i],
-                task_group=tg,
+                group=tg,
             )
-            rt.fill(
-                of_lut[i].prod(),
+            of_lut_prods[i].fill(
                 B,
                 angle_taps[i],
-                task_group=tg,
+                group=tg,
             )
         # Drain the output objectFIFOs with data
         for i in range(num_aie_columns):
-            rt.drain(
-                of_out[i].cons(),
+            of_out_conss[i].drain(
                 C,
                 tensor_taps[i],
                 wait=True,  # wait for the transfer to complete and data to be available
-                task_group=tg,
+                group=tg,
             )
-        rt.finish_task_group(tg)
+        tg.finish()
 
+    rt = Runtime(
+        sequence,
+        [
+            tensor_ty,
+            angle_ty,
+            tensor_ty,
+            [of.prod() for of in of_in],
+            [of.prod() for of in of_lut],
+            [of.cons() for of in of_out],
+        ],
+    )
     # Place program components (assign them resources on the device) and generate an MLIR module
-    return Program(dev, rt).resolve_program()
+    prog = Program(dev, rt, workers=my_workers)
+    maybe_enable_trace(prog, trace_size, my_workers)
+    return prog.resolve_program()

--- a/iron/operators/softmax/design.py
+++ b/iron/operators/softmax/design.py
@@ -10,9 +10,11 @@ from aie.iron import (
     ScratchpadParameter,
     Program,
     Runtime,
+    TaskGroup,
     Worker,
     Buffer,
     WorkerRuntimeBarrier,
+    sync_parameters,
 )
 from aie.iron.device import NPU1, NPU2
 from aie.helpers.taplib.tap import TensorAccessPattern
@@ -156,51 +158,54 @@ def softmax(
     ]
 
     # Runtime operations to move data to/from the AIE-array
-    rt = Runtime()
-    with rt.sequence(tensor_ty, tensor_ty) as (A, C):
-        maybe_enable_trace(rt, trace_size, my_workers)
-        rt.start(*my_workers)
-
+    def sequence(A, C, in1_prods, out_conses):
         if use_scratchpad:
             # The host writes vector_size into the scratchpad via
             # ParameterScratchpad before each dispatch; sync delivers it to the
             # per-core parameter buffer.
-            rt.sync_parameters()
+            sync_parameters()
         else:
             # Set the static (compile-time) run-time parameter controlling how
             # many elements each core processes.
-            def set_rtps(*args):
-                for rtp in args:
-                    rtp[0] = rtp_vector_size
-
-            rt.inline_ops(set_rtps, rtps)
+            for rtp in rtps:
+                rtp[0] = rtp_vector_size
 
         for i in range(num_aie_columns * num_channels):
-            rt.set_barrier(barriers[i], 1)
+            barriers[i].set(1)
 
         # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
-        tg = rt.task_group()
+        tg = TaskGroup()
 
         # Fill the input objectFIFOs with data
         for i in range(num_aie_columns):
             for j in range(num_channels):
-                rt.fill(
-                    of_in1s[i * num_channels + j].prod(),
+                in1_prods[i * num_channels + j].fill(
                     A,
                     taps[i * num_channels + j],
-                    task_group=tg,
+                    group=tg,
                 )
         # Drain the output objectFIFOs with data
         for i in range(num_aie_columns):
             for j in range(num_channels):
-                rt.drain(
-                    of_outs[i * num_channels + j].cons(),
+                out_conses[i * num_channels + j].drain(
                     C,
                     taps[i * num_channels + j],
                     wait=True,  # wait for the transfer to complete and data to be available
-                    task_group=tg,
+                    group=tg,
                 )
-        rt.finish_task_group(tg)
+        tg.finish()
+
+    rt = Runtime(
+        sequence,
+        [
+            tensor_ty,
+            tensor_ty,
+            [of.prod() for of in of_in1s],
+            [of.cons() for of in of_outs],
+        ],
+    )
 
     # Place program components (assign them resources on the device) and generate an MLIR module
-    return Program(dev, rt).resolve_program()
+    prog = Program(dev, rt, workers=my_workers)
+    maybe_enable_trace(prog, trace_size, my_workers)
+    return prog.resolve_program()

--- a/iron/operators/strided_copy/design.py
+++ b/iron/operators/strided_copy/design.py
@@ -11,7 +11,14 @@ input[0, :, 0] -> output[:, 0, 0]
 import numpy as np
 
 from aie.dialects.aiex import TensorAccessPattern
-from aie.iron import ObjectFifo, ScratchpadParameter, Program, Runtime
+from aie.iron import (
+    ObjectFifo,
+    Program,
+    Runtime,
+    ScratchpadParameter,
+    TaskGroup,
+    sync_parameters,
+)
 
 
 def strided_copy(
@@ -130,27 +137,33 @@ def strided_copy(
         for c in range(num_aie_channels)
     ]
 
-    rt = Runtime()
-    with rt.sequence(inp_ty, out_ty) as (inp, out):
+    def sequence(inp, out, fifos_in_prods, fifos_out_conss):
         if in_offset_param is not None or out_offset_param is not None:
-            rt.sync_parameters()
-        tg = rt.task_group()
+            sync_parameters()
+        tg = TaskGroup()
         for c in range(num_aie_channels):
-            rt.fill(
-                fifos_in[c].prod(),
+            fifos_in_prods[c].fill(
                 inp,
                 input_taps[c],
-                task_group=tg,
+                group=tg,
                 offset_parameter=in_offset_param,
             )
-            rt.drain(
-                fifos_out[c].cons(),
+            fifos_out_conss[c].drain(
                 out,
                 output_taps[c],
-                task_group=tg,
+                group=tg,
                 wait=True,
                 offset_parameter=out_offset_param,
             )
-        rt.finish_task_group(tg)
+        tg.finish()
 
+    rt = Runtime(
+        sequence,
+        [
+            inp_ty,
+            out_ty,
+            [of.prod() for of in fifos_in],
+            [of.cons() for of in fifos_out],
+        ],
+    )
     return Program(dev, rt).resolve_program()

--- a/iron/operators/transpose/design.py
+++ b/iron/operators/transpose/design.py
@@ -4,7 +4,7 @@
 from ml_dtypes import bfloat16
 import numpy as np
 
-from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, TaskGroup, Worker
 from aie.helpers.taplib.tap import TensorAccessPattern
 from aie.iron.controlflow import range_
 
@@ -152,36 +152,41 @@ def shuffle_transpose(
     ]
 
     # Runtime operations to move data to/from the AIE-array
-    rt = Runtime()
-    with rt.sequence(tensor_ty, tensor_ty) as (A, C):
-        rt.start(*my_workers)
+    def sequence(A, C, of_in1s_L3L2_prods, of_outs_conss):
 
         # One task group per batch (each a parallel fill+drain over all columns/channels), so the
         # num_batches contiguous matrices stream through the same FIFOs in sequence.
         for batch in range(num_batches):
             # Initialize a group for parallel drain tasks, with fill resources free'd when drains complete.
-            tg = rt.task_group()
+            tg = TaskGroup()
 
             # Fill the input objectFIFOs with data
             for i in range(num_columns):
                 for j in range(num_channels):
-                    rt.fill(
-                        of_in1s_L3L2[i * num_channels + j].prod(),
+                    of_in1s_L3L2_prods[i * num_channels + j].fill(
                         A,
                         taps_in_L3L2[i * num_channels + j][batch],
-                        task_group=tg,
+                        group=tg,
                     )
             # Drain the output objectFIFOs of data
             for i in range(num_columns):
                 for j in range(num_channels):
-                    rt.drain(
-                        of_outs[i * num_channels + j].cons(),
+                    of_outs_conss[i * num_channels + j].drain(
                         C,
                         taps_out_L1L3[i * num_channels + j][batch],
                         wait=True,  # wait for the transfer to complete and data to be available
-                        task_group=tg,
+                        group=tg,
                     )
-            rt.finish_task_group(tg)
+            tg.finish()
 
+    rt = Runtime(
+        sequence,
+        [
+            tensor_ty,
+            tensor_ty,
+            [of.prod() for of in of_in1s_L3L2],
+            [of.cons() for of in of_outs],
+        ],
+    )
     # Place program components (assign them resources on the device) and generate an MLIR module
-    return Program(dev, rt).resolve_program()
+    return Program(dev, rt, workers=my_workers).resolve_program()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,11 @@
 # CUDA build served from PyPI. We therefore also pin torch to the "+cpu" local
 # version below, which is only available from the PyTorch CPU index.
 --index-url https://download.pytorch.org/whl/cpu
---find-links https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4
+--find-links https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0
 --find-links https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 --extra-index-url https://pypi.org/simple
 
-mlir_aie==1.3.5.dev20+g167f34d
+mlir_aie==1.4.0
 llvm-aie==21.0.0.2026062301+cb664e8c
 
 black


### PR DESCRIPTION
This updates mlir-aie from v1.3.5.dev20+g167f34d to v1.4.0 and migrates the
operator library to the APIs that release ships, so the bump builds.

Supersedes #144, which changes `requirements.txt` alone. I hit this running the
operator library against a v1.4.0-era mlir-aie on Strix, so the changes here are
what it took to get back to green rather than a reading of the changelog.

## Why the bump alone does not build

Two breaking changes landed in mlir-aie after the pinned v1.3.5.dev20 (which is
mlir-aie 167f34d, 8 July) and before v1.4.0.

**#3387 reworked the IRON Runtime into a callback body.**

| before | after |
|---|---|
| `Runtime()` + `with rt.sequence(*tys) as (...)` | `Runtime(seq_fn, fn_args)` |
| `rt.fill(h, src, ...)` / `rt.drain(h, dst, ...)` | `h.fill(src, ...)` / `h.drain(dst, ...)` |
| `rt.start(*workers)` | `Program(dev, rt, workers=workers)` |
| `rt.task_group()` / `rt.finish_task_group(tg)` | `TaskGroup()` / `tg.finish()` |
| `rt.set_barrier(b, 1)` | `b.set(1)` |
| `rt.inline_ops(fn, args)` | call `fn` directly |
| `rt.enable_trace(...)` | `Program.enable_trace(...)` |
| `rt.sync_parameters()` | `iron.sync_parameters()` |
| `task_group=` | `group=` |

The per-transfer `tile=` argument also goes away: placement is now a property of
the handle, so it is bound once on `.prod(tile=...)` / `.cons(tile=...)` instead
of being repeated on every `fill`/`drain`.

**#3364 unified aiecc's output selection under `--get-<name>`**, removing
`--aie-generate-xclbin`, `--aie-generate-npu-insts`, `--generate-full-elf` and
`--no-compile-host`. `iron/common/compilation/base.py` still emitted all of them,
so nothing compiled at all. The xclbin path and the full-ELF path both died on
the first argument aiecc did not recognise.

| before | after |
|---|---|
| `--aie-generate-xclbin` | `--get-xclbin` |
| `--aie-generate-npu-insts` | `--get-npu-insts` |
| `--generate-full-elf` | `--get-full-elf` |
| `--no-compile-host` | dropped |
| `--no-compile` | dropped |

The last two are deletions rather than renames. Requesting only `--get-npu-insts`
and not `--get-xclbin` is precisely what `--no-compile` used to mean, so output
selection by omission replaces it.

## Two places that needed more than a rename

**`gemm` records tensor access patterns from inside the sequence body.** The body
now runs at `resolve_program()` rather than at `Runtime()` construction, so with a
literal translation `generate_taps=True` would have returned three empty
sequences, quietly and with no error. The program is now resolved before the taps
are read.

**`mem_copy` guarded `rt.start` on `not bypass`.** Since workers moved to the
`Program` constructor, that becomes `workers=None if bypass else my_workers`;
translating the guard literally would have started workers in the bypass path.

## Testing

`pytest iron/operators` on Strix (npu2), full suite including the `extensive`
set, against a local build of mlir-aie at the v1.4.0 API.

```
2810 passed, 5 skipped in 1021.64s
```

All 21 operator suites green. That includes the configurations that exercise the
parts of this change that needed judgement rather than a rename: `mem_copy` with
`bypass=True` (the conditional-workers case), `mha` at both 4 and 8 pipelines
(the 4-pipeline arm is the one where the second Q/O handle pair is absent) and
its GQA case, and `swiglu_decode`/`swiglu_prefill`, which are the only operators
taking the full-ELF path.

Three branches no test reaches, checked by generating their MLIR directly:

- `gemm` with `generate_taps=True` returns 8/8/4 non-empty access patterns. Under
  a literal translation this returns three empty sequences with no error, which
  is what motivated the reorder above.
- `gemm` with `separate_c_tiles=True`, used by `iron/applications/llama_3.2_1b`
  but by no test, still builds.
- `strided_copy` has no `test.py` at all. Both paths build, and the
  offset-parameter path still emits `aiex.sync_scratchpad_parameters_from_host`,
  the `offset_parameter` BD attributes and the `aiex.scratchpad_parameter`
  declaration.

Still unverified: `softmax` with `vector_size_parameter` set, and the
`llama_3.2_1b` end-to-end chain. Both are reachable only from that application,
whose tests skip without `IRON_EXAMPLE_WEIGHTS_DIR`, so I could not run them.

`black` and `reuse lint` clean.

## Not included

The nightly `update-mlir-aie.yml` run that opened #144 reported failure even
though the PR was created: after pushing the branch it calls `workflow_dispatch`
on a workflow that has no such trigger, gets HTTP 422, and exits 1. That is why
#144 carries no checks. It is unrelated to this migration, and would fail on any
bump, so it is worth a separate fix.
