### PR TITLE
Rename CI jobs

### DIFF
--- a/.github/workflows/krackan-examples.yml
+++ b/.github/workflows/krackan-examples.yml
@@ -16,7 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Test:
+  test_examples_on_krackan:
+    name: Test Examples on Krackan
     runs-on: [self-hosted, krackan]
     steps:
       - name: Checkout

--- a/.github/workflows/krackan-examples.yml
+++ b/.github/workflows/krackan-examples.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - devel
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/krackan-extensive.yml
+++ b/.github/workflows/krackan-extensive.yml
@@ -19,7 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Test:
+  test_extensive_on_krackan:
+    name: Test Extensive Suite on Krackan
     runs-on: [self-hosted, krackan]
     steps:
       - name: Pull

--- a/.github/workflows/krackan-small.yml
+++ b/.github/workflows/krackan-small.yml
@@ -10,6 +10,7 @@ on:
      branches:
        - main
        - devel
+  merge_group:
 
 # VJUNG: Introduce concurrency groups named with branch refs.
 # VJUNG: If one pushes 5 times on its branch only the most recent commit will trigger CI.

--- a/.github/workflows/krackan-small.yml
+++ b/.github/workflows/krackan-small.yml
@@ -18,7 +18,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Test:
+  test_small_on_krackan:
+    name: Test Small Suite on Krackan
     runs-on: [self-hosted, krackan]
     steps:
       - name: Pull

--- a/.github/workflows/phoenix-extensive.yml
+++ b/.github/workflows/phoenix-extensive.yml
@@ -19,7 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Test:
+  test_extensive_on_phoenix:
+    name: Test Extensive Suite on Phoenix
     runs-on: [self-hosted, phoenix]
     steps:
       - name: Pull

--- a/.github/workflows/phoenix-small.yml
+++ b/.github/workflows/phoenix-small.yml
@@ -10,6 +10,7 @@ on:
      branches:
        - main
        - devel
+  merge_group:
 
 # VJUNG: Introduce concurrency groups named with branch refs.
 # VJUNG: If one pushes 5 times on its branch only the most recent commit will trigger CI.

--- a/.github/workflows/phoenix-small.yml
+++ b/.github/workflows/phoenix-small.yml
@@ -18,7 +18,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Test:
+  test_small_on_phoenix:
+    name: Test Small Suite on Phoenix
     runs-on: [self-hosted, phoenix]
     steps:
       - name: Pull

--- a/.github/workflows/phoenix-test-examples.yml
+++ b/.github/workflows/phoenix-test-examples.yml
@@ -16,7 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Test:
+  test_examples_on_phoenix:
+    name: Test Examples on Phoenix
     runs-on: [self-hosted, phoenix]
     steps:
       - name: Checkout

--- a/.github/workflows/phoenix-test-examples.yml
+++ b/.github/workflows/phoenix-test-examples.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - devel
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The CI jobs were all named "Test", making it impossible to mark each of them as "required check" in the GitHub web interface. With the higher volume of PRs we're getting, I'd like to enable the merge queue, and making these CI tests required is a prerequisite for that.