### PR TITLE
test_utils: make exact equality expressible in verify_buffer

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -143,10 +143,16 @@ def pytest_runtest_makereport(item, call):
             nodeid_components = re.match(
                 r"^(.+?::[^\[]+)\[(iter\d+-)?(.+?)\]$", item.nodeid
             )
-            if not nodeid_components:
-                raise RuntimeError(f"Unexpected test nodeid format: {item.nodeid}")
-            test_path = nodeid_components.group(1)
-            test_name = nodeid_components.group(3)
+            if nodeid_components:
+                test_path = nodeid_components.group(1)
+                test_name = nodeid_components.group(3)
+            else:
+                # A test with no parameters carries no [...] suffix at all. The
+                # iteration parametrize that would otherwise supply one is only
+                # added when --iterations > 1, so this is reachable at
+                # --iterations 1 and used to abort the whole session.
+                test_path = item.nodeid
+                test_name = item.nodeid.rsplit("::", 1)[-1]
 
             passed = report.outcome == "passed"
             captured = report.capstdout

--- a/conftest.py
+++ b/conftest.py
@@ -147,10 +147,8 @@ def pytest_runtest_makereport(item, call):
                 test_path = nodeid_components.group(1)
                 test_name = nodeid_components.group(3)
             else:
-                # A test with no parameters carries no [...] suffix at all. The
-                # iteration parametrize that would otherwise supply one is only
-                # added when --iterations > 1, so this is reachable at
-                # --iterations 1 and used to abort the whole session.
+                # A test with no parameters carries no [...] suffix, so won't
+                # match the regex above.
                 test_path = item.nodeid
                 test_name = item.nodeid.rsplit("::", 1)[-1]
 

--- a/iron/common/test_utils.py
+++ b/iron/common/test_utils.py
@@ -99,7 +99,11 @@ def verify_buffer(
         + np.abs(expected_np[:compare_len].astype(float)),
         np.finfo(np.float32).max,
     )
-    mask = diff >= np.maximum(abs_tol, rel_tol * norm)
+    # Fail on diff STRICTLY past the threshold. With >=, rel_tol=abs_tol=0 makes the
+    # threshold 0 and every element fails, so a bit-identical buffer scores 100% errors
+    # and exact equality -- the honest gate for an operator that does no arithmetic --
+    # cannot be expressed at all.
+    mask = diff > np.maximum(abs_tol, rel_tol * norm)
     error_indices = np.where(mask)[0].tolist()
     for i in error_indices[:10]:
         print(

--- a/iron/common/test_utils.py
+++ b/iron/common/test_utils.py
@@ -99,7 +99,7 @@ def verify_buffer(
         + np.abs(expected_np[:compare_len].astype(float)),
         np.finfo(np.float32).max,
     )
-    # Use `>`, not `>=`, here, so that a user can pass rel_tol=abs_tol=0 
+    # Use `>`, not `>=`, here, so that a user can pass rel_tol=abs_tol=0
     # check exact equality.
     mask = diff > np.maximum(abs_tol, rel_tol * norm)
     error_indices = np.where(mask)[0].tolist()

--- a/iron/common/test_utils.py
+++ b/iron/common/test_utils.py
@@ -99,10 +99,8 @@ def verify_buffer(
         + np.abs(expected_np[:compare_len].astype(float)),
         np.finfo(np.float32).max,
     )
-    # Fail on diff STRICTLY past the threshold. With >=, rel_tol=abs_tol=0 makes the
-    # threshold 0 and every element fails, so a bit-identical buffer scores 100% errors
-    # and exact equality -- the honest gate for an operator that does no arithmetic --
-    # cannot be expressed at all.
+    # Use `>`, not `>=`, here, so that a user can pass rel_tol=abs_tol=0 
+    # check exact equality.
     mask = diff > np.maximum(abs_tol, rel_tol * norm)
     error_indices = np.where(mask)[0].tolist()
     for i in error_indices[:10]:

--- a/iron/tests/infrastructure/comparison.py
+++ b/iron/tests/infrastructure/comparison.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""What the tolerances in verify_buffer are required to mean.
+
+An operator that does no arithmetic (transpose, mem_copy) should be gated on exact
+equality, not on a tolerance that would also accept a wrong answer. That is
+rel_tol=abs_tol=0, so the zero case has to behave -- and it is the case a
+threshold comparison is easiest to get backwards, since the threshold is then the
+same value as the difference between two identical buffers.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from iron.common.test_utils import verify_buffer
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_zero_tolerance_accepts_an_identical_buffer(dtype):
+    buf = (torch.arange(64, dtype=torch.float32) / 8).to(dtype)
+
+    assert verify_buffer(buf, "out", buf.clone(), rel_tol=0.0, abs_tol=0.0) == []
+
+
+@pytest.mark.parametrize("rel_tol,abs_tol", [(0.0, 0.0), (0.04, 1e-6)])
+def test_a_single_wrong_element_is_reported_alone(rel_tol, abs_tol):
+    reference = torch.arange(64, dtype=torch.float32)
+    output = reference.clone()
+    output[
+        17
+    ] += 10.0  # past the 4% relative tolerance at this magnitude, not just past 0
+
+    assert verify_buffer(output, "out", reference, rel_tol, abs_tol) == [17]
+
+
+def test_zero_tolerance_still_rejects_a_one_ulp_error():
+    """The point of the zero case is that it is exact, not that it is lenient."""
+    reference = torch.full((32,), 1.0, dtype=torch.float32)
+    output = reference.clone()
+    output[5] = float(np.nextafter(np.float32(1.0), np.float32(2.0)))
+
+    assert verify_buffer(output, "out", reference, rel_tol=0.0, abs_tol=0.0) == [5]
+    # The default tolerance is meant to absorb exactly this.
+    assert verify_buffer(output, "out", reference) == []


### PR DESCRIPTION

`verify_buffer` thresholds on `diff >= np.maximum(abs_tol, rel_tol * norm)`. Set both
tolerances to 0 and the threshold is 0, so `diff >= 0` holds for every element of a
bit-identical buffer: two copies of the same tensor score 100% errors. Exact equality
is not a strict gate today, it is an unusable one, and it cannot tell a perfect result
from a broken one. `nearly_equal`, directly above it in the same file, has the explicit
`if a == b: return True` escape that the vectorised path never grew.

That matters for the operators that do no arithmetic — transpose, mem_copy,
strided_copy, repeat — which currently have no way to ask for the gate they want.

The comparison is now strict, which is also what `np.isclose` means by its tolerances.
The new mask is a subset of the old one, so nothing that passes today can start failing;
only elements exactly at the threshold change verdict, and at the default 1e-6 / 0.04
that is measure-zero on float data.

## Added
- `iron/tests/infrastructure/comparison.py`: an identical buffer passes at 0/0 in f32 and
  bf16, one wrong element is reported alone at both 0/0 and the defaults, and 0/0 still
  rejects a one-ulp error that the default absorbs. 50 passed here, 40 of the 50 fail
  against the unfixed helper.

## Changed
- `iron/common/test_utils.py`: `>=` to `>` in the threshold comparison.
- `conftest.py`: the CSV reporting hook required a `[...]` suffix on every nodeid and
  raised otherwise, so a test with no parameters aborted the session. On devel today,
  `pytest iron/tests/stream/names.py --iterations 1` dies with an INTERNALERROR on
  `test_module_parameters_cover_the_golden_weights`. Included here because the new file
  adds another unparametrized test; the bug predates it.

## Removed
-

## Scope
CI runs `iron/operators` and `iron/applications` and never passes `--iterations`, so
neither the conftest path nor the new test file is reachable from CI as configured.
