### PR TITLE
strided_copy: fix the num_aie_channels>1 device hang, and add test coverage

### DIFF
--- a/iron/operators/strided_copy/design.py
+++ b/iron/operators/strided_copy/design.py
@@ -55,9 +55,23 @@ def strided_copy(
         output_sizes[output_highest_sz_idx] % num_aie_channels == 0
     ), "Highest dimension of output_sizes must be divisible by num_aie_channels"
 
+    # Each channel's BD carries 1/num_aie_channels of the tensor, so the ObjectFifo object
+    # is sized against the per-channel share. A BD shorter than the object starves the
+    # MemTile's S2MM -- it never completes an object, never releases the lock, and the
+    # drain's dma_await_task never returns (ERT_CMD_STATE_TIMEOUT). An integer multiple is
+    # fine; it just cycles the buffer.
+    assert int(np.prod(input_sizes)) == int(np.prod(output_sizes)), (
+        f"a copy moves the same element count both ways: input_sizes {input_sizes} "
+        f"has {int(np.prod(input_sizes))} elements, output_sizes {output_sizes} has "
+        f"{int(np.prod(output_sizes))}"
+    )
+    per_channel_size = int(np.prod(input_sizes)) // num_aie_channels
     if transfer_size is None:
-        transfer_size = int(np.prod(input_sizes))
-    assert np.prod(input_sizes) % transfer_size == 0
+        transfer_size = per_channel_size
+    assert per_channel_size % transfer_size == 0, (
+        f"transfer_size {transfer_size} must divide the per-channel transfer "
+        f"{per_channel_size} (= {int(np.prod(input_sizes))} / {num_aie_channels} channels)"
+    )
     transfer_ty = np.ndarray[
         (transfer_size,),
         np.dtype[dtype],

--- a/iron/operators/strided_copy/op.py
+++ b/iron/operators/strided_copy/op.py
@@ -95,6 +95,6 @@ class StridedCopy(MLIROperator):
 
     def get_arg_spec(self):
         return [
-            AIERuntimeArgSpec("in", self.input_buffer_size),
-            AIERuntimeArgSpec("out", self.output_buffer_size),
+            AIERuntimeArgSpec("in", (int(self.input_buffer_size),)),
+            AIERuntimeArgSpec("out", (int(self.output_buffer_size),)),
         ]

--- a/iron/operators/strided_copy/reference.py
+++ b/iron/operators/strided_copy/reference.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import torch
+
+from iron.common.test_utils import torch_dtype_map
+
+
+def _pad_to_4d(sizes, strides):
+    """design.py pads access patterns to 4D before building the taps; the reference
+    has to pad identically or the per-channel split lands on a different dimension."""
+    return (
+        [1] * (4 - len(sizes)) + list(sizes),
+        [0] * (4 - len(strides)) + list(strides),
+    )
+
+
+def _tap_offsets(sizes, strides, offset):
+    """Flat element offsets a TensorAccessPattern visits, in issue order."""
+    grids = np.meshgrid(*[np.arange(s) for s in sizes], indexing="ij")
+    flat = np.full(grids[0].shape, offset, dtype=np.int64)
+    for grid, stride in zip(grids, strides):
+        flat = flat + grid * stride
+    return flat.reshape(-1)
+
+
+def _channel_offsets(sizes, strides, offset, num_aie_channels):
+    sizes, strides = _pad_to_4d(sizes, strides)
+    highest = max(idx for idx, sz in enumerate(sizes) if sz >= 1)
+    per_channel = sizes[highest] // num_aie_channels
+    split = sizes[:highest] + [per_channel] + sizes[highest + 1 :]
+    return [
+        _tap_offsets(split, strides, offset + c * per_channel * strides[highest])
+        for c in range(num_aie_channels)
+    ]
+
+
+def reference(
+    input_flat,
+    input_sizes,
+    input_strides,
+    input_offset,
+    output_buffer_size,
+    output_sizes,
+    output_strides,
+    output_offset,
+    num_aie_channels=1,
+    input_offset_addend=0,
+    output_offset_addend=0,
+):
+    """Gather by the input tap, scatter by the output tap, one channel at a time.
+
+    The addends are the *_offset_parameter values. They are element counts, not byte
+    offsets: the firmware multiplies the scratchpad word by the element size before
+    adding it into the BD address register.
+    """
+    src = _channel_offsets(
+        input_sizes, input_strides, input_offset + input_offset_addend, num_aie_channels
+    )
+    dst = _channel_offsets(
+        output_sizes,
+        output_strides,
+        output_offset + output_offset_addend,
+        num_aie_channels,
+    )
+
+    out = torch.zeros(int(output_buffer_size), dtype=input_flat.dtype)
+    for src_c, dst_c in zip(src, dst):
+        if len(src_c) != len(dst_c):
+            raise ValueError(
+                f"tap element counts differ ({len(src_c)} vs {len(dst_c)}); "
+                "the input and output access patterns must move the same number "
+                "of elements"
+            )
+        out[dst_c] = input_flat[src_c]
+    return out
+
+
+def generate_golden_reference(
+    input_buffer_size,
+    input_sizes,
+    input_strides,
+    input_offset,
+    output_buffer_size,
+    output_sizes,
+    output_strides,
+    output_offset,
+    num_aie_channels=1,
+    input_offset_addend=0,
+    output_offset_addend=0,
+    dtype="bf16",
+    seed=42,
+):
+    torch.manual_seed(seed)
+    val_range = 4
+    input_tensor = (
+        torch.rand(int(input_buffer_size), dtype=torch_dtype_map[dtype]) * val_range
+    )
+    output_tensor = reference(
+        input_tensor,
+        input_sizes,
+        input_strides,
+        input_offset,
+        output_buffer_size,
+        output_sizes,
+        output_strides,
+        output_offset,
+        num_aie_channels=num_aie_channels,
+        input_offset_addend=input_offset_addend,
+        output_offset_addend=output_offset_addend,
+    )
+    return {"input": input_tensor, "output": output_tensor}

--- a/iron/operators/strided_copy/test.py
+++ b/iron/operators/strided_copy/test.py
@@ -73,8 +73,7 @@ def get_params():
 )
 @pytest.mark.parametrize("kwargs", get_params())
 def test_strided_copy(kwargs, aie_context):
-    """StridedCopy moves data and computes nothing, so the gate is exact equality.
-    """
+    """StridedCopy moves data and computes nothing, so the gate is exact equality."""
     # transfer_size only sizes the ObjectFifo; it does not move the data anywhere else,
     # so the golden is computed without it.
     golden_kwargs = {k: v for k, v in kwargs.items() if k != "transfer_size"}

--- a/iron/operators/strided_copy/test.py
+++ b/iron/operators/strided_copy/test.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from iron.operators.strided_copy.op import StridedCopy
+from iron.operators.strided_copy.reference import generate_golden_reference
+from iron.common.test_utils import run_test
+
+# Llama's KV-cache write, shrunk: the cache is (n_kv_groups, seq, head_dim) and one
+# token's keys land in slot t of every group. SEQ is 128 rather than the real 2048 to
+# keep the output buffer at 128 KB; the full-size arm is extensive.
+N_KV, HEAD_DIM, SEQ = 8, 64, 128
+
+
+def _kv_slot(seq, slot, num_aie_channels=1):
+    """StridedCopy kwargs writing one (N_KV, HEAD_DIM) token into cache slot `slot`."""
+    return dict(
+        input_sizes=[N_KV, HEAD_DIM],
+        input_strides=[HEAD_DIM, 1],
+        input_offset=0,
+        input_buffer_size=N_KV * HEAD_DIM,
+        output_sizes=[1, N_KV, HEAD_DIM],
+        output_strides=[0, seq * HEAD_DIM, 1],
+        output_offset=slot * HEAD_DIM,
+        output_buffer_size=N_KV * seq * HEAD_DIM,
+        num_aie_channels=num_aie_channels,
+    )
+
+
+def _flat(size, num_aie_channels=1, transfer_size=None):
+    return dict(
+        input_sizes=[size],
+        input_strides=[1],
+        input_offset=0,
+        input_buffer_size=size,
+        output_sizes=[size],
+        output_strides=[1],
+        output_offset=0,
+        output_buffer_size=size,
+        num_aie_channels=num_aie_channels,
+        transfer_size=transfer_size,
+    )
+
+
+def get_params():
+    return [
+        pytest.param(_flat(1024), id="contiguous"),
+        # num_aie_channels splits the highest dimension across that many shim channels.
+        # Sweep it at the default transfer_size and at a divisor of the per-channel share:
+        # the object has to divide the per-channel BD, and the default used to be sized
+        # against the whole tensor, which hung every channel count above 1.
+        pytest.param(_flat(1024, num_aie_channels=2), id="two_channels"),
+        pytest.param(_flat(1024, num_aie_channels=4), id="four_channels"),
+        pytest.param(
+            _flat(1024, num_aie_channels=2, transfer_size=256),
+            id="two_channels_chunked",
+        ),
+        pytest.param(_flat(1024, transfer_size=256), id="chunked_transfer"),
+        pytest.param(_kv_slot(SEQ, 0), id="kv_slot0"),
+        pytest.param(_kv_slot(SEQ, 5), id="kv_slot5"),
+        pytest.param(_kv_slot(SEQ, SEQ - 1), id="kv_slot_last"),
+        # The KV-cache write is what num_aie_channels exists to widen, so it carries the
+        # strided arms too -- the flat cases split a stride-1 run, these split head_dim.
+        pytest.param(_kv_slot(SEQ, 5, num_aie_channels=2), id="kv_slot5_two_channels"),
+        pytest.param(_kv_slot(SEQ, 5, num_aie_channels=4), id="kv_slot5_four_channels"),
+        pytest.param(
+            _kv_slot(2048, 1000), id="kv_llama_full", marks=[pytest.mark.extensive]
+        ),
+    ]
+
+
+@pytest.mark.metrics(
+    Latency=r"Latency \(us\): (?P<value>[\d\.]+)",
+    Bandwidth=r"Effective Bandwidth: (?P<value>[\d\.e\+-]+) GB/s",
+)
+@pytest.mark.parametrize("kwargs", get_params())
+def test_strided_copy(kwargs, aie_context):
+    """StridedCopy moves data and computes nothing, so the gate is exact equality.
+
+    The kv_slot arms write one token into a cache slot and leave the rest of the
+    buffer alone, which is the shape that matters: a tolerance gate would accept a
+    copy that landed in the wrong slot, and a wrong slot is what a mis-scaled offset
+    produces.
+    """
+    # transfer_size only sizes the ObjectFifo; it does not move the data anywhere else,
+    # so the golden is computed without it.
+    golden_kwargs = {k: v for k, v in kwargs.items() if k != "transfer_size"}
+    golden_ref = generate_golden_reference(**golden_kwargs)
+
+    operator = StridedCopy(**kwargs, context=aie_context)
+
+    errors, latency_us, bandwidth_gbps = run_test(
+        operator,
+        {"input": golden_ref["input"]},
+        {"output": golden_ref["output"]},
+        rel_tol=0.0,
+        abs_tol=0.0,
+    )
+
+    print(f"\nLatency (us): {latency_us:.1f}")
+    print(f"Effective Bandwidth: {bandwidth_gbps:.6e} GB/s\n")
+
+    assert not errors, f"Test failed with errors: {errors}"
+
+
+def test_transfer_size_not_dividing_per_channel_share_is_rejected(aie_context):
+    """A BD shorter than the ObjectFifo object hangs the device, so it must not compile.
+
+    4 channels over 1024 elements is a 256-element BD; a 512-element object leaves the
+    MemTile's S2MM waiting for a second half that no channel sends, and the drain's
+    dma_await_task returns ERT_CMD_STATE_TIMEOUT with no diagnostic.
+    """
+    operator = StridedCopy(
+        **_flat(1024, num_aie_channels=4, transfer_size=512), context=aie_context
+    )
+    with pytest.raises(AssertionError, match="must divide the per-channel transfer"):
+        operator.compile()

--- a/iron/operators/strided_copy/test.py
+++ b/iron/operators/strided_copy/test.py
@@ -47,10 +47,6 @@ def _flat(size, num_aie_channels=1, transfer_size=None):
 def get_params():
     return [
         pytest.param(_flat(1024), id="contiguous"),
-        # num_aie_channels splits the highest dimension across that many shim channels.
-        # Sweep it at the default transfer_size and at a divisor of the per-channel share:
-        # the object has to divide the per-channel BD, and the default used to be sized
-        # against the whole tensor, which hung every channel count above 1.
         pytest.param(_flat(1024, num_aie_channels=2), id="two_channels"),
         pytest.param(_flat(1024, num_aie_channels=4), id="four_channels"),
         pytest.param(
@@ -78,11 +74,6 @@ def get_params():
 @pytest.mark.parametrize("kwargs", get_params())
 def test_strided_copy(kwargs, aie_context):
     """StridedCopy moves data and computes nothing, so the gate is exact equality.
-
-    The kv_slot arms write one token into a cache slot and leave the rest of the
-    buffer alone, which is the shape that matters: a tolerance gate would accept a
-    copy that landed in the wrong slot, and a wrong slot is what a mis-scaled offset
-    produces.
     """
     # transfer_size only sizes the ObjectFifo; it does not move the data anywhere else,
     # so the golden is computed without it.


### PR DESCRIPTION

Stacked on #157: the new tests gate at exact equality, which #157 is what makes
expressible. Its two commits are in this diff and drop out when it merges.

`transfer_size` defaults to the product of the whole `input_sizes`, but the channel
split happens afterwards, so at `num_aie_channels > 1` the ObjectFifo object is N times
the length of the shim BD feeding it. A BD shorter than its object starves the MemTile's
S2MM: it never completes an object, never releases the lock, the linked MM2S never
starts, and the drain's `dma_await_task` never returns. The host sees
`ERT_CMD_STATE_TIMEOUT`. Generation, the MLIR verifier and the xclbin build are all clean.

An integer multiple is fine — it just cycles the buffer. Stated as that ratio, it
predicted 8 of 8 arms on a sweep across channels 1/2/4 x transfer_size. `num_aie_channels=4`
lands on both sides — passes at `transfer_size=256`, hangs at 512 — which is what rules
out a multi-channel defect and leaves the ratio.

The operator also had no tests, and could not have had: `get_arg_spec` passed a bare int
where `AIERuntimeArgSpec.shape` is a tuple, and `XRTTensor` only treats a tuple as a shape.
Anything else goes through `np.asarray`, so the int becomes a 0-d array and the output
buffer is allocated for one element. It is the only one of the tree's 35 arg-spec call
sites that passes a scalar.

## Added
- `iron/operators/strided_copy/test.py` and `reference.py`. Arms cover contiguous, chunked,
  2 and 4 channels, and Llama's KV-cache write shape at several slots, plus a construction-time
  rejection test. Gated at `rel_tol=abs_tol=0` — the operator does no arithmetic.

## Changed
- `design.py`: size the object against the per-channel share, and assert the divisibility
  the hardware requires, so ratio < 1 is a construction-time rejection instead of a device
  hang. Also assert that a copy moves the same element count both ways, which nothing
  checked and which fails the same undiagnosable way on the output side.
- `op.py`: the arg spec now passes a shape tuple.

## Removed
-

## Evidence
On devel with `design.py` reverted, exactly the four multi-channel arms fail with
`ERT_CMD_STATE_TIMEOUT` and the single-channel and chunked arms pass. With the fix,
11/11 pass at exact equality. Arithmetic at `num_aie_channels=1` is unchanged, so
`llama_npu.py`'s KV-cache write — the only in-tree caller — is untouched.

## Known gap
`llama_npu.py` drives the output offset at runtime through a `ScratchpadParameter`
(`output_offset_parameter="cache_offset"`). The new arms bake the offset as a compile-time
constant instead, so that path is still uncovered.
