### PR TITLE
transpose, mem_copy: gate the pure-movement operators exactly

### DIFF
--- a/iron/operators/mem_copy/test.py
+++ b/iron/operators/mem_copy/test.py
@@ -78,7 +78,12 @@ def test_mem_copy(
     output_buffers = {"output": golden_ref["output"]}
 
     errors, latency_us, bandwidth_gbps = run_test(
-        operator, input_buffers, output_buffers, rel_tol=0.01, abs_tol=1e-6
+        # A copy that alters a value is a broken copy, so gate it exactly.
+        operator,
+        input_buffers,
+        output_buffers,
+        rel_tol=0.0,
+        abs_tol=0.0,
     )
 
     print(f"\nLatency (us): {latency_us:.1f}")

--- a/iron/operators/transpose/test.py
+++ b/iron/operators/transpose/test.py
@@ -97,7 +97,13 @@ def test_transpose(M, N, aie_columns, channels, m, n, s, num_batches, aie_contex
     output_buffers = {"output": golden_ref["output"]}
 
     errors, latency_us, bandwidth_gbps = run_test(
-        operator, input_buffers, output_buffers, rel_tol=0.04, abs_tol=1e-6
+        # A transpose is a permutation. Any tolerance here also accepts some class of
+        # wrong permutation, so gate it exactly.
+        operator,
+        input_buffers,
+        output_buffers,
+        rel_tol=0.0,
+        abs_tol=0.0,
     )
 
     print(f"\nLatency (us): {latency_us:.1f}")


### PR DESCRIPTION

Stacked on #157, which is what makes `rel_tol=abs_tol=0` mean exact rather than "fail
everything". Its two commits are in this diff and drop out when it merges.

Neither operator computes anything — transpose is a permutation, mem_copy is a copy — so
the tolerances they run under (0.04 and 0.01) also accept some class of wrong answer.
For a permutation that class includes landing in the wrong place, which is exactly what
a mis-scaled offset or a mis-split dimension produces.

## Added
-

## Changed
- `iron/operators/transpose/test.py`, `iron/operators/mem_copy/test.py`: gate at
  `rel_tol=abs_tol=0`.

## Removed
-

## Evidence
96/96 pass on npu2, every arm including the extensive ones: 32 transpose, 64 mem_copy.
