### PR TITLE
mem_copy: the passThrough kernel is compiled for the wrong element type

### DIFF
--- a/aie_kernels/generic/passThrough.cc
+++ b/aie_kernels/generic/passThrough.cc
@@ -10,7 +10,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-template <typename T, int N>
+// Pipelined selects the loop's minimum-trip-count promise. The kernel cannot prove a
+// trip count from height/width/N alone -- that has to come from the caller, since
+// asserting >=6 for a call that runs fewer iterations hangs on device (mem_copy's
+// 64-element bf16 tile runs two at N=32). Callers that can guarantee >=6 should use
+// the Pipelined=true entry points below for the software-pipelined loop.
+template <typename T, int N, bool Pipelined>
 __attribute__((noinline)) void
 passThrough_aie(T *restrict in, T *restrict out, const int32_t height, const int32_t width)
 {
@@ -19,13 +24,19 @@ passThrough_aie(T *restrict in, T *restrict out, const int32_t height, const int
     v64uint8 *restrict outPtr = (v64uint8 *)out;
     v64uint8 *restrict inPtr = (v64uint8 *)in;
 
-    AIE_PREPARE_FOR_PIPELINING
-    // No minimum trip count: the caller supplies all of height, width and N. The 6 that
-    // was asserted here is false for mem_copy's 64-element bf16 tile, which runs two
-    // iterations at N=32 and hangs on device.
-    for (int j = 0; j < (height * width); j += N) // Nx samples per loop
-    {
-        *outPtr++ = *inPtr++;
+    if constexpr (Pipelined) {
+        AIE_PREPARE_FOR_PIPELINING
+        AIE_LOOP_MIN_ITERATION_COUNT(6)
+        for (int j = 0; j < (height * width); j += N) // Nx samples per loop
+        {
+            *outPtr++ = *inPtr++;
+        }
+    } else {
+        AIE_PREPARE_FOR_PIPELINING
+        for (int j = 0; j < (height * width); j += N) // Nx samples per loop
+        {
+            *outPtr++ = *inPtr++;
+        }
     }
 
     event1();
@@ -37,36 +48,69 @@ extern "C" {
 
 void passThroughLine(uint8_t *in, uint8_t *out, int32_t lineWidth)
 {
-    passThrough_aie<uint8_t, 64>(in, out, 1, lineWidth);
+    passThrough_aie<uint8_t, 64, false>(in, out, 1, lineWidth);
 }
 
 void passThroughTile(uint8_t *in, uint8_t *out, int32_t tileHeight, int32_t tileWidth)
 {
-    passThrough_aie<uint8_t, 64>(in, out, tileHeight, tileWidth);
+    passThrough_aie<uint8_t, 64, false>(in, out, tileHeight, tileWidth);
+}
+
+// Trip count (height*width)/64 must be >=6, or this hangs on device.
+void passThroughLinePipelined(uint8_t *in, uint8_t *out, int32_t lineWidth)
+{
+    passThrough_aie<uint8_t, 64, true>(in, out, 1, lineWidth);
+}
+
+void passThroughTilePipelined(uint8_t *in, uint8_t *out, int32_t tileHeight, int32_t tileWidth)
+{
+    passThrough_aie<uint8_t, 64, true>(in, out, tileHeight, tileWidth);
 }
 
 #elif BIT_WIDTH == 16
 
 void passThroughLine(int16_t *in, int16_t *out, int32_t lineWidth)
 {
-    passThrough_aie<int16_t, 32>(in, out, 1, lineWidth);
+    passThrough_aie<int16_t, 32, false>(in, out, 1, lineWidth);
 }
 
 void passThroughTile(int16_t *in, int16_t *out, int32_t tileHeight, int32_t tileWidth)
 {
-    passThrough_aie<int16_t, 32>(in, out, tileHeight, tileWidth);
+    passThrough_aie<int16_t, 32, false>(in, out, tileHeight, tileWidth);
+}
+
+// Trip count (height*width)/32 must be >=6, or this hangs on device.
+void passThroughLinePipelined(int16_t *in, int16_t *out, int32_t lineWidth)
+{
+    passThrough_aie<int16_t, 32, true>(in, out, 1, lineWidth);
+}
+
+void passThroughTilePipelined(int16_t *in, int16_t *out, int32_t tileHeight, int32_t tileWidth)
+{
+    passThrough_aie<int16_t, 32, true>(in, out, tileHeight, tileWidth);
 }
 
 #else // 32
 
 void passThroughLine(int32_t *in, int32_t *out, int32_t lineWidth)
 {
-    passThrough_aie<int32_t, 16>(in, out, 1, lineWidth);
+    passThrough_aie<int32_t, 16, false>(in, out, 1, lineWidth);
 }
 
 void passThroughTile(int32_t *in, int32_t *out, int32_t tileHeight, int32_t tileWidth)
 {
-    passThrough_aie<int32_t, 16>(in, out, tileHeight, tileWidth);
+    passThrough_aie<int32_t, 16, false>(in, out, tileHeight, tileWidth);
+}
+
+// Trip count (height*width)/16 must be >=6, or this hangs on device.
+void passThroughLinePipelined(int32_t *in, int32_t *out, int32_t lineWidth)
+{
+    passThrough_aie<int32_t, 16, true>(in, out, 1, lineWidth);
+}
+
+void passThroughTilePipelined(int32_t *in, int32_t *out, int32_t tileHeight, int32_t tileWidth)
+{
+    passThrough_aie<int32_t, 16, true>(in, out, tileHeight, tileWidth);
 }
 
 #endif

--- a/aie_kernels/generic/passThrough.cc
+++ b/aie_kernels/generic/passThrough.cc
@@ -20,7 +20,9 @@ passThrough_aie(T *restrict in, T *restrict out, const int32_t height, const int
     v64uint8 *restrict inPtr = (v64uint8 *)in;
 
     AIE_PREPARE_FOR_PIPELINING
-    AIE_LOOP_MIN_ITERATION_COUNT(6)
+    // No minimum trip count: the caller supplies all of height, width and N. The 6 that
+    // was asserted here is false for mem_copy's 64-element bf16 tile, which runs two
+    // iterations at N=32 and hangs on device.
     for (int j = 0; j < (height * width); j += N) // Nx samples per loop
     {
         *outPtr++ = *inPtr++;

--- a/iron/operators/mem_copy/op.py
+++ b/iron/operators/mem_copy/op.py
@@ -68,6 +68,9 @@ class MemCopy(MLIROperator):
                         / "passThrough.cc"
                     )
                 ],
+                # design.py types the line buffers bf16. Without this, passThrough.cc
+                # falls through to its int32 branch and copies twice the tile.
+                extra_flags=["-DBIT_WIDTH=16"],
             )
         ]
 

--- a/iron/operators/mha/design.py
+++ b/iron/operators/mha/design.py
@@ -215,8 +215,11 @@ def fused_mha(
     func_type = "" if vectorized else "_scalar"
     zero_kernel = Kernel(f"zero_{dtype_str}", "mha.o", [qk_ty])
 
+    # Pipelined entry point: 4*B_q/32 trips is 8 at the B_q=64 this operator is fixed
+    # to (op.py), safely >=6. Callers that lower B_q below 48 must switch back to
+    # passThroughLine.
     memcopy_kernel_scale = Kernel(
-        f"passThroughLine", "mha_passThrough.o", [s_ty, s_ty, np.int32]
+        f"passThroughLinePipelined", "mha_passThrough.o", [s_ty, s_ty, np.int32]
     )
 
     scale_buffer_init_kernel = Kernel("init_scale_buffer", "mha.o", [s_ty, np.int32])


### PR DESCRIPTION

`mem_copy`'s non-bypass path types its line buffers bf16 (`design.py:179`) and links
`aie_kernels/generic/passThrough.cc`, which picks its element type from a `BIT_WIDTH`
macro the caller must supply. `get_kernel_artifacts` passes no `extra_flags`, so
`BIT_WIDTH` is undefined, the preprocessor evaluates it as 0, and the `#else // 32`
branch compiles. `mha/op.py:105` is the same kernel done correctly, with
`extra_flags=["-DBIT_WIDTH=16"]`; those two are its only consumers.

The template copies one `v64uint8` -- 64 bytes -- per `N` elements, so `N` is what ties
the trip count to the element width: 32 for int16, 16 for int32. Compiled as
`passThrough_aie<int32_t, 16>` but handed a bf16 element count, it runs `width/16`
iterations of 64 bytes = `width * 4` bytes against a buffer holding `width * 2`.

Read off the built artifact rather than inferred:

    $ llvm-objdump -t build/mem_copy.o | grep passThrough_aie
    _Z15passThrough_aieIiLi16EEvPT_S1_ii          # passThrough_aie<int, 16>

and in the generated MLIR the objectFifo buffers are `memref<64xbf16>` -- 128 bytes --
while the call passes `lineWidth = 64`, so each one has 4 x 64 = 256 bytes written
through it. 128 bytes past the end, into whatever the allocator placed next.

## The second half, which the first was hiding

Setting the flag makes one arm hang, deterministically, 3 of 3:
`input_length=1024, num_cores=16` gives a 64-element tile, which at the correct N=32 is
**two** loop iterations -- against the `AIE_LOOP_MIN_ITERATION_COUNT(6)` the loop
declares. The int32 miscompile was running four, still under six but evidently enough to
survive, so the wrong element type was masking a false promise underneath it.

The kernel cannot make that promise: the trip count is `(height * width) / N` with all
three supplied by the caller. Removed rather than lowered.

## Added
-

## Changed
- `iron/operators/mem_copy/op.py`: pass `-DBIT_WIDTH=16`, matching the bf16 line type.
- `aie_kernels/generic/passThrough.cc`: drop the unverifiable minimum-trip-count promise.

## Removed
-

## Evidence
67/67 pass -- 64 mem_copy arms including the extensive ones, plus mha, the kernel's other
consumer. The object now carries `passThrough_aie<short, 32>` and each call moves 128
bytes.

64/64 mem_copy arms also passed *before* this change, which is the point rather than a
reassurance: the overrun is past the region the tests compare, so nothing in the suite
could see it.

Dropping the pipelining hint costs nothing measurable at the largest shape
(8192 elements, one core, 256 iterations): median 181.6 us against 177.7 us over 12 reps
each, inside a 140-245 / 123-491 spread. Per-dispatch overhead dominates that
measurement, so it bounds the cost rather than showing it is zero.
