### PR TITLE
Copy aiecc work-dir inputs when Windows denies symlinks.

### DIFF
--- a/iron/common/compilation/base.py
+++ b/iron/common/compilation/base.py
@@ -518,8 +518,14 @@ def _link_build_outputs_into(work_dir: Path, build_dir: Path) -> None:
         if entry.is_dir():
             continue
         link = work_dir / entry.name
-        if not link.exists():
-            link.symlink_to(entry.resolve())
+        if link.exists():
+            continue
+        target = entry.resolve()
+        try:
+            link.symlink_to(target)
+        except OSError:
+            # Windows without Developer Mode cannot create symlinks.
+            shutil.copy2(target, link)
 
 
 class AieccCompilationRule(CompilationRule):


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

aiecc looks up kernel objects in a per-artifact work dir. We currently symlink those files from the shared build dir. On Windows without Developer Mode, `Path.symlink_to` raises `OSError` and compile fails. Fall back to `shutil.copy2` so the same lookup still works.

## Added
- Copy fallback in `_link_build_outputs_into` when symlink creation is denied.

## Changed
- `_link_build_outputs_into` still prefers a symlink; it copies only on `OSError`.

## Removed
-

## PR Merge Checklist

1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
