### PR TITLE
Re-export operator classes lazily.

### DIFF
--- a/iron/operators/__init__.py
+++ b/iron/operators/__init__.py
@@ -1,17 +1,42 @@
 # SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from .elementwise_add.op import ElementwiseAdd
-from .elementwise_mul.op import ElementwiseMul
-from .gemm.op import GEMM
-from .gemv.op import GEMV
-from .mha.op import MHA
-from .rms_norm.op import RMSNorm
-from .rope.op import RoPE
-from .silu.op import SiLU
-from .softmax.op import Softmax
-from .swiglu_decode.op import SwiGLUDecode
-from .swiglu_prefill.op import SwiGLUPrefill
-from .transpose.op import Transpose
-from .strided_copy.op import StridedCopy
-from .repeat.op import Repeat
+"""The IRON operator library.
+
+Operators are re-exported lazily (PEP 562):
+
+    from iron.operators import GEMM  # imports iron.operators.gemm.op, nothing else
+"""
+
+import importlib
+
+_OPERATOR_MODULES = {
+    "ElementwiseAdd": "elementwise_add",
+    "ElementwiseMul": "elementwise_mul",
+    "GEMM": "gemm",
+    "GEMV": "gemv",
+    "MHA": "mha",
+    "RMSNorm": "rms_norm",
+    "RoPE": "rope",
+    "SiLU": "silu",
+    "Softmax": "softmax",
+    "SwiGLUDecode": "swiglu_decode",
+    "SwiGLUPrefill": "swiglu_prefill",
+    "Transpose": "transpose",
+    "StridedCopy": "strided_copy",
+    "Repeat": "repeat",
+}
+
+__all__ = sorted(_OPERATOR_MODULES)
+
+
+def __getattr__(name):
+    """Import the operator that defines `name`, on first access."""
+    module = _OPERATOR_MODULES.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return getattr(importlib.import_module(f".{module}.op", __name__), name)
+
+
+def __dir__():
+    return sorted(set(globals()) | set(_OPERATOR_MODULES))

--- a/iron/tests/infrastructure/lazy_imports.py
+++ b/iron/tests/infrastructure/lazy_imports.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Importing one operator must not import the rest of the catalog."""
+
+import sys
+
+from iron.operators import ElementwiseAdd
+
+
+def test_lazy_catalog_does_not_import_mha():
+    assert ElementwiseAdd.__name__ == "ElementwiseAdd"
+    assert "iron.operators.mha.op" not in sys.modules
+    assert "iron.operators.swiglu_decode.op" not in sys.modules


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

`iron.operators` bound every operator class in `__init__.py`. Importing one name, or even `import iron.operators.elementwise_add.op`, therefore imported the whole catalog: Python loads parent packages first, so the eager `__init__` ran before the operator you asked for.

Each `iron.operators.<name>.op` module does not need to import the others. PEP 562 `__getattr__` keeps the same public names and only loads the operator that was asked for. A broken or heavy import in one operator then cannot fail compile or use of another.

## Added
- PEP 562 `__getattr__` / `__dir__` re-exports for the existing operator class names.
- `iron/tests/infrastructure/lazy_imports.py`: `ElementwiseAdd` does not import MHA or SwiGLU.

## Changed
- `iron.operators` public names are unchanged; they are imported on first access.

## Removed
- Eager `from .mha.op import MHA` (and the other catalog imports) from `iron/operators/__init__.py`.

## PR Merge Checklist
1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.