### PR TITLE
Allow compiling MHA and OperatorSequence without torch.

### DIFF
--- a/iron/common/sequence.py
+++ b/iron/common/sequence.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import numpy as np
 import ml_dtypes
 import pyxrt
-import torch
 from . import compilation as comp
 from .base import AIEOperatorBase, MLIROperator
 import aie.utils as aie_utils
@@ -18,6 +17,18 @@ from aie.utils.hostruntime.tensor_class import CPUOnlyTensor
 from aie.utils.npukernel import NPUKernel
 
 logger = logging.getLogger(__name__)
+
+
+def _torch():
+    """Import torch for CPU reference/compare paths. Compile and NPU dispatch do not."""
+    try:
+        import torch
+    except ImportError as exc:
+        raise RuntimeError(
+            "OperatorSequence CPU reference/compare modes need torch. "
+            "Compile and NPU dispatch do not."
+        ) from exc
+    return torch
 
 
 # ##########################################################################
@@ -754,6 +765,7 @@ class SequenceReferenceCallable(_PerBufferCallable):
         return view
 
     def _run(self):
+        torch = _torch()
         for step_op, in_names, in_specs, out_name, out_spec in self._iter_steps():
             inputs = [
                 _reshape_for_spec(self._resolve_buffer(n).torch_view(), s).clone()
@@ -800,6 +812,7 @@ class SequenceCompareCallable(SequenceXclbinCallable):
 
         kernel(*args)
 
+        torch = _torch()
         npu_out = self._read_to_cpu(out_name, out_spec).to(torch.float32)
         ref_out = step_op.reference(*cpu_inputs)
 

--- a/iron/operators/mha/op.py
+++ b/iron/operators/mha/op.py
@@ -4,9 +4,7 @@
 from dataclasses import dataclass, field
 from typing import ClassVar, Dict
 
-import torch
 import numpy as np
-from ml_dtypes import bfloat16
 
 from iron.common import (
     MLIROperator,
@@ -130,10 +128,9 @@ class MHA(MLIROperator):
             return tensor
 
         pad_size = padded_seq_len - seq_len
-        pad_dims = [0] * (2 * tensor.ndim)
-        pad_dims[2 * (tensor.ndim - 1 - seq_dim) + 1] = pad_size
-
-        return torch.nn.functional.pad(tensor, pad_dims)
+        pad_width = [(0, 0)] * tensor.ndim
+        pad_width[seq_dim] = (0, pad_size)
+        return np.pad(tensor, pad_width)
 
     def _pack_compact_to_padded(
         self, src: np.ndarray, H: int, S: int, S_pad: int, D: int

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 dependencies = [
     "numpy",
-    "torch",
     "ml_dtypes",
 ]
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

Compile and NPU dispatch do not use torch. MHA imported it at module load for padding, and `OperatorSequence` imported it for CPU reference/compare. Move torch off the compile path so those modules import with compiler-stack only. Tests and CPU goldens still use torch via `requirements.txt`.

## Added
- NumPy pad for MHA sequence padding.
- Lazy `_torch()` import on the sequence CPU reference/compare paths.

## Changed
- `pyproject.toml` package deps are numpy and ml_dtypes. Torch stays in `requirements.txt` for tests.

## Removed
- `import torch` from `iron/operators/mha/op.py` and from `iron.common.sequence` module load.
- Torch as a hard `pyproject.toml` dependency.

## PR Merge Checklist
1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
