### PR TITLE
Allow compiling OperatorSequence without XRT.

### DIFF
--- a/iron/common/sequence.py
+++ b/iron/common/sequence.py
@@ -7,14 +7,24 @@ import time
 from pathlib import Path
 import numpy as np
 import ml_dtypes
-import pyxrt
 from . import compilation as comp
 from .base import AIEOperatorBase, MLIROperator
 import aie.utils as aie_utils
 from aie.iron.device import NPU2
-from aie.utils.hostruntime.xrtruntime.tensor import XRTTensor
 from aie.utils.hostruntime.tensor_class import CPUOnlyTensor
 from aie.utils.npukernel import NPUKernel
+
+try:
+    import pyxrt
+    from aie.utils.hostruntime.xrtruntime.tensor import XRTTensor
+except ImportError:
+    # Host stacks without XRT (e.g. the HRX/amdxdna runtime) have no pyxrt. The two
+    # on-device dispatch policies below are XRT-native (pyxrt.elf / hw_context / run,
+    # plus XRTTensor views), so they cannot run there; _require_xrt() makes that
+    # explicit at construction. The CPU policy and the whole compile path do not care,
+    # and must keep importing.
+    pyxrt = None
+    XRTTensor = None
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +39,17 @@ def _torch():
             "Compile and NPU dispatch do not."
         ) from exc
     return torch
+
+
+def _require_xrt() -> None:
+    """Fail with the reason, rather than an AttributeError on ``None.elf``."""
+    if pyxrt is None:
+        raise RuntimeError(
+            "this OperatorSequence dispatch policy needs the XRT host runtime (pyxrt), "
+            "which is not installed. Use SequenceCPUCallable, or run a single operator "
+            "(AIEOperatorBase), which dispatches through aie.utils.DefaultNPURuntime and "
+            "works on any backend."
+        )
 
 
 # ##########################################################################
@@ -553,6 +574,7 @@ class SequenceFullELFCallable(SequenceCallable):
     """
 
     def __init__(self, op, device_name="main", sequence_name="sequence"):
+        _require_xrt()
         self.device_name = device_name
         self.sequence_name = sequence_name
 
@@ -697,6 +719,7 @@ class SequenceXclbinCallable(_PerBufferCallable):
     """
 
     def __init__(self, op, dispatch):
+        _require_xrt()
         self._dispatch = dispatch
         super().__init__(op)
 

--- a/iron/common/test_utils.py
+++ b/iron/common/test_utils.py
@@ -8,7 +8,6 @@ import torch
 import aie.utils as aie_utils
 from ml_dtypes import bfloat16
 from .base import AIEOperatorBase
-from aie.utils.hostruntime.xrtruntime.tensor import XRTTensor
 
 torch_dtype_map = {
     "bf16": torch.bfloat16,
@@ -126,6 +125,17 @@ def verify_buffer(
     return errors
 
 
+def _nbytes(buf) -> int:
+    """Bytes of tensor data moved, for the effective-bandwidth figure.
+
+    Reads the numpy view rather than the backend buffer handle: ``buffer_object()``
+    returns a ``pyxrt.bo`` under XRT but an opaque handle under HRX, so ``.size()`` is
+    not part of the Tensor interface. The view is also the more honest number -- it is
+    the payload, not the (page-rounded) allocation.
+    """
+    return buf.data.nbytes
+
+
 def run_test(
     operator: AIEOperatorBase,
     input_buffers: dict[str, torch.Tensor],
@@ -169,34 +179,40 @@ def run_test(
 
     total_bytes = 0
 
+    # The device tensor type of whichever host runtime is selected (IRON_RUNTIME):
+    # XRTTensor under XRT, HRXTensor under HRX. Both implement the Tensor interface
+    # this function uses, and the operator dispatches through DefaultNPURuntime, which
+    # is the matching runtime.
+    tensor_class = aie_utils.DEFAULT_TENSOR_CLASS
+
     for spec in arg_spec:
         if spec.direction == "in":
             try:
                 name, data = next(input_iter)
             except StopIteration:
                 raise ValueError("Not enough input buffers provided for arg spec")
-            buf = XRTTensor.from_torch(data)
+            buf = tensor_class.from_torch(data)
             args.append(buf)
-            total_bytes += buf.buffer_object().size()
+            total_bytes += _nbytes(buf)
         elif spec.direction == "out":
             try:
                 name, expected = next(output_iter)
             except StopIteration:
                 raise ValueError("Not enough output buffers provided for arg spec")
-            buf = XRTTensor(spec.shape, dtype=spec.dtype)
+            buf = tensor_class(spec.shape, dtype=spec.dtype)
             args.append(buf)
             output_map[name] = buf
-            total_bytes += buf.buffer_object().size()
+            total_bytes += _nbytes(buf)
         elif spec.direction == "inout":
             try:
                 name, data = next(input_iter)
             except StopIteration:
                 raise ValueError("Not enough input buffers provided for inout arg spec")
-            buf = XRTTensor.from_torch(data)
+            buf = tensor_class.from_torch(data)
             args.append(buf)
             output_map[name] = buf
             inout_names.append(name)
-            total_bytes += buf.buffer_object().size()
+            total_bytes += _nbytes(buf)
         else:
             raise ValueError(f"Unsupported direction: {spec.direction}")
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

`OperatorSequence` imported `pyxrt` and `XRTTensor` at module load, so compiling SwiGLU (or any sequence) required XRT even though compile and the CPU dispatch path do not use it. Make those imports optional. XRT-native dispatch policies still need pyxrt and fail at construction if it is missing. `run_test` uses `aie.utils.DEFAULT_TENSOR_CLASS` so operator tests follow `IRON_RUNTIME` instead of hard-coding XRT.

## Added
- Optional `pyxrt` / `XRTTensor` import in `iron.common.sequence`.
- `_require_xrt()` on the full-ELF and chained-xclbin callables.

## Changed
- `run_test` allocates buffers with `DEFAULT_TENSOR_CLASS` and measures payload size from the numpy view.

## Removed
- Unconditional `import pyxrt` and `XRTTensor` from `sequence.py` and `test_utils.py`.

## PR Merge Checklist
1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
