### PR TITLE
strided_copy: cover the runtime offset parameter, fix its comment

### DIFF
--- a/iron/operators/strided_copy/design.py
+++ b/iron/operators/strided_copy/design.py
@@ -90,8 +90,9 @@ def strided_copy(
     # aiex.scratchpad_parameter used to patch the DMA BD base address at runtime. The
     # statically-computed offset is used as the base; the parameter's value is
     # additively combined onto it inside the BD address registers via UPDATE_REG.
-    # The host writes the byte offset into the ctrl scratchpad before each
-    # dispatch via ParameterScratchpad.
+    # The host writes an ELEMENT count into the ctrl scratchpad before each
+    # dispatch via ParameterScratchpad; the firmware multiplies by elemBytes
+    # before adding it into the address register.
     in_offset_param = (
         ScratchpadParameter(input_offset_parameter, np.int32)
         if input_offset_parameter is not None

--- a/iron/operators/strided_copy/design.py
+++ b/iron/operators/strided_copy/design.py
@@ -86,13 +86,9 @@ def strided_copy(
         np.dtype[dtype],
     ]
 
-    # input_offset_parameter (and output_offset_parameter) is the name of an
-    # aiex.scratchpad_parameter used to patch the DMA BD base address at runtime. The
-    # statically-computed offset is used as the base; the parameter's value is
-    # additively combined onto it inside the BD address registers via UPDATE_REG.
-    # The host writes an ELEMENT count into the ctrl scratchpad before each
-    # dispatch via ParameterScratchpad; the firmware multiplies by elemBytes
-    # before adding it into the address register.
+    # Patches the DMA BD base address at runtime: the static offset is the base,
+    # and UPDATE_REG adds the parameter onto it. The host writes an element count,
+    # which the firmware scales by elemBytes.
     in_offset_param = (
         ScratchpadParameter(input_offset_parameter, np.int32)
         if input_offset_parameter is not None

--- a/iron/operators/strided_copy/test.py
+++ b/iron/operators/strided_copy/test.py
@@ -2,11 +2,14 @@
 # SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import numpy as np
 import pytest
+import torch
 
 from iron.operators.strided_copy.op import StridedCopy
 from iron.operators.strided_copy.reference import generate_golden_reference
-from iron.common.test_utils import run_test
+from iron.common.sequence import OperatorSequence
+from iron.common.test_utils import run_test, verify_buffer
 
 # Llama's KV-cache write, shrunk: the cache is (n_kv_groups, seq, head_dim) and one
 # token's keys land in slot t of every group. SEQ is 128 rather than the real 2048 to
@@ -93,6 +96,60 @@ def test_strided_copy(kwargs, aie_context):
     print(f"Effective Bandwidth: {bandwidth_gbps:.6e} GB/s\n")
 
     assert not errors, f"Test failed with errors: {errors}"
+
+
+@pytest.mark.supported_devices("npu2")
+def test_strided_copy_cache_offset_parameter(aie_context):
+    """llama_npu.py:319 is the operator's only production caller and drives
+    the KV-cache write's slot through output_offset_parameter
+    (ParameterScratchpad), with output_offset=0 as the base -- every arm
+    above bakes the offset in at compile time instead, so this path has no
+    coverage.
+
+    dispatch="fused" is the only mode with a ctrl scratchpad. Drives
+    cache_offset through one persistent run handle across three token
+    positions and checks the full cache buffer each time: a mis-scaled
+    addend (elements vs bytes) lands the write in the wrong slot, which a
+    target-slot-only check would miss.
+    """
+    base_kwargs = _kv_slot(SEQ, 0)
+    op = StridedCopy(
+        **base_kwargs, output_offset_parameter="cache_offset", context=aie_context
+    )
+    seq = OperatorSequence(
+        "strided_copy_cache_offset_cov",
+        [(op, "in", "out")],
+        input_args=["in"],
+        output_args=["out"],
+        dispatch="fused",
+        context=aie_context,
+    )
+    seq.compile()
+    run = seq.get_callable()
+    assert run.params is not None, "cache_offset did not produce a ctrl scratchpad"
+
+    out_buf = run.get_buffer("out")
+    expected = torch.zeros(base_kwargs["output_buffer_size"], dtype=torch.bfloat16)
+    out_buf.torch_view()[: expected.numel()] = expected
+    out_buf.to("npu")
+
+    for i, slot in enumerate((0, 5, SEQ - 1)):
+        golden = generate_golden_reference(
+            **base_kwargs, output_offset_addend=slot * HEAD_DIM, seed=i + 1
+        )
+        expected += golden["output"]
+
+        in_buf = run.get_buffer("in")
+        in_buf.torch_view()[: golden["input"].numel()] = golden["input"]
+        in_buf.to("npu")
+
+        run.params.write("cache_offset", np.int32(slot * HEAD_DIM))
+        run.params.sync()
+        run()
+
+        out = out_buf.torch_view()[: expected.numel()].clone()
+        errors = verify_buffer(out, "out", expected, rel_tol=0.0, abs_tol=0.0)
+        assert not errors, f"slot {slot}: {errors}"
 
 
 def test_transfer_size_not_dividing_per_channel_share_is_rejected(aie_context):

--- a/iron/operators/strided_copy/test.py
+++ b/iron/operators/strided_copy/test.py
@@ -100,17 +100,10 @@ def test_strided_copy(kwargs, aie_context):
 
 @pytest.mark.supported_devices("npu2")
 def test_strided_copy_cache_offset_parameter(aie_context):
-    """llama_npu.py:319 is the operator's only production caller and drives
-    the KV-cache write's slot through output_offset_parameter
-    (ParameterScratchpad), with output_offset=0 as the base -- every arm
-    above bakes the offset in at compile time instead, so this path has no
-    coverage.
+    """dispatch="fused" is the only mode with a ctrl scratchpad.
 
-    dispatch="fused" is the only mode with a ctrl scratchpad. Drives
-    cache_offset through one persistent run handle across three token
-    positions and checks the full cache buffer each time: a mis-scaled
-    addend (elements vs bytes) lands the write in the wrong slot, which a
-    target-slot-only check would miss.
+    The whole cache is checked rather than the target slot: a mis-scaled addend
+    (elements vs bytes) lands the write in a different slot.
     """
     base_kwargs = _kv_slot(SEQ, 0)
     op = StridedCopy(


### PR DESCRIPTION
## Problem
llama_npu.py:319 is strided_copy's only production caller, and it drives the
KV-cache write's offset at runtime through `output_offset_parameter` (a
`ParameterScratchpad`), with the static `output_offset` as the base. #158 (now merged) names this as a known gap in its own body: every arm it added bakes the offset in at
compile time instead, so the operator's only production path has no test
coverage. Separately, design.py's comment on this parameter says the host
writes a byte offset into the scratchpad; it writes an element count, and the
firmware multiplies by elemBytes.

## Fix
Adds `test_strided_copy_cache_offset_parameter`, gated
`@pytest.mark.supported_devices("npu2")`. It wraps StridedCopy in a
single-entry `OperatorSequence(dispatch="fused")` (the only dispatch mode
with a ctrl scratchpad) and drives `cache_offset` through
`ParameterScratchpad` across three token positions on one compiled program
and one persistent run handle, the same handle reuse the decode path
depends on. Each iteration checks the full cache buffer, not just the target
slot: a mis-scaled addend lands the write in the wrong slot, which a
target-slot-only check would miss. Also corrects the design.py comment.

## Test/Evidence
I did not run this on hardware. `black --check` and `reuse lint` pass on
both changed files. This op has no kernel, so the only device-free check
available is the reference math itself: a standalone script that calls
`reference.py`'s `generate_golden_reference` for the same three slots used
in the test confirms their write regions are disjoint (1536 of 65536
elements, no overlap), each token's data round-trips exactly through the
accumulated buffer at its own indices, and doubling the addend (the shape a
byte-vs-element bug would take) produces a different result rather than one
silently masked by the gate.
CI's krackan-small job runs `pytest -m "not extensive" iron/operators/` on
self-hosted NPU2 hardware, which is where `supported_devices("npu2")` lets
this arm actually execute; I have not seen that run.
