### PR TITLE
mha: size the K/V arg specs by num_KV_heads, not num_heads

### DIFF
--- a/iron/operators/mha/op.py
+++ b/iron/operators/mha/op.py
@@ -108,12 +108,16 @@ class MHA(MLIROperator):
 
     def get_arg_spec(self):
         seq_padding = self._calculate_seq_padding(self.seq_len, self.num_of_pipelines)
-        buffer_size = self.num_heads * self.d * seq_padding
+        # design.py declares Q and O as (heads, S_q_pad, d) but K and V as
+        # (num_KV_heads, S_kv_pad * d), and treats num_KV_heads == 0 as plain MHA.
+        kv_heads = self.num_KV_heads if self.num_KV_heads else self.num_heads
+        q_size = self.num_heads * self.d * seq_padding
+        kv_size = kv_heads * self.d * seq_padding
         return [
-            AIERuntimeArgSpec("in", (buffer_size,)),  # Q
-            AIERuntimeArgSpec("in", (buffer_size,)),  # K
-            AIERuntimeArgSpec("in", (buffer_size,)),  # V
-            AIERuntimeArgSpec("out", (buffer_size,)),  # O
+            AIERuntimeArgSpec("in", (q_size,)),  # Q
+            AIERuntimeArgSpec("in", (kv_size,)),  # K
+            AIERuntimeArgSpec("in", (kv_size,)),  # V
+            AIERuntimeArgSpec("out", (q_size,)),  # O
         ]
 
     def _calculate_seq_padding(self, seq_len, num_pipeline=1):

--- a/iron/operators/mha/op.py
+++ b/iron/operators/mha/op.py
@@ -108,8 +108,8 @@ class MHA(MLIROperator):
 
     def get_arg_spec(self):
         seq_padding = self._calculate_seq_padding(self.seq_len, self.num_of_pipelines)
-        # design.py declares Q and O as (heads, S_q_pad, d) but K and V as
-        # (num_KV_heads, S_kv_pad * d), and treats num_KV_heads == 0 as plain MHA.
+        # design.py declares Q/O as (heads, S_q_pad, d) and K/V as
+        # (num_KV_heads, S_kv_pad * d); num_KV_heads == 0 means plain MHA.
         kv_heads = self.num_KV_heads if self.num_KV_heads else self.num_heads
         q_size = self.num_heads * self.d * seq_padding
         kv_size = kv_heads * self.d * seq_padding

--- a/iron/operators/mha/test.py
+++ b/iron/operators/mha/test.py
@@ -80,3 +80,40 @@ def test_mha(seq_len, dim, num_heads, num_pipelines, num_kv_heads, aie_context):
     assert (
         len(errors["O"]) <= max_acceptable_errors
     ), f"Test failed with {len(errors['O'])} errors (max allowable: {max_acceptable_errors})"
+
+
+@pytest.mark.parametrize(
+    "seq_len,dim,num_heads,num_pipelines,num_kv_heads",
+    [
+        # GQA: 8 query heads against 2 KV heads. K/V are a quarter of Q/O.
+        (16384, 64, 8, 8, 2),
+        # Standard MHA: num_kv_heads == 0 means num_kv_heads == num_heads.
+        (16384, 64, 1, 8, 0),
+    ],
+)
+def test_arg_spec_matches_design_shapes(
+    seq_len, dim, num_heads, num_pipelines, num_kv_heads
+):
+    """get_arg_spec sizes the runtime buffers; design.py declares the MLIR arg types.
+
+    Under GQA the two disagree on K and V by num_heads/num_KV_heads. Nothing catches
+    it today: run_test sizes input buffers from the supplied tensor rather than from
+    the spec, so only a fused OperatorSequence -- which asserts the MLIR arg count
+    equals the computed one -- would notice.
+    """
+    op = MHA(
+        num_heads=num_heads,
+        seq_len=seq_len,
+        d=dim,
+        num_KV_heads=num_kv_heads,
+        num_of_pipelines=num_pipelines,
+    )
+    q, k, v, o = (spec.shape[0] for spec in op.get_arg_spec())
+
+    # design.py: Q_ty is (heads, S_q_pad, d), KV_ty is (num_KV_heads, S_kv_pad * d).
+    pad = op._calculate_seq_padding(seq_len, num_pipelines)
+    kv_heads = num_kv_heads if num_kv_heads else num_heads
+    assert q == num_heads * pad * dim
+    assert o == num_heads * pad * dim
+    assert k == kv_heads * pad * dim
+    assert v == kv_heads * pad * dim

--- a/iron/operators/mha/test.py
+++ b/iron/operators/mha/test.py
@@ -85,21 +85,16 @@ def test_mha(seq_len, dim, num_heads, num_pipelines, num_kv_heads, aie_context):
 @pytest.mark.parametrize(
     "seq_len,dim,num_heads,num_pipelines,num_kv_heads",
     [
-        # GQA: 8 query heads against 2 KV heads. K/V are a quarter of Q/O.
         (16384, 64, 8, 8, 2),
-        # Standard MHA: num_kv_heads == 0 means num_kv_heads == num_heads.
+        # num_kv_heads == 0 means plain MHA.
         (16384, 64, 1, 8, 0),
     ],
 )
 def test_arg_spec_matches_design_shapes(
     seq_len, dim, num_heads, num_pipelines, num_kv_heads
 ):
-    """get_arg_spec sizes the runtime buffers; design.py declares the MLIR arg types.
-
-    Under GQA the two disagree on K and V by num_heads/num_KV_heads. Nothing catches
-    it today: run_test sizes input buffers from the supplied tensor rather than from
-    the spec, so only a fused OperatorSequence -- which asserts the MLIR arg count
-    equals the computed one -- would notice.
+    """get_arg_spec sizes the runtime buffers; design.py declares the MLIR arg
+    types. The two must agree.
     """
     op = MHA(
         num_heads=num_heads,
@@ -110,7 +105,6 @@ def test_arg_spec_matches_design_shapes(
     )
     q, k, v, o = (spec.shape[0] for spec in op.get_arg_spec())
 
-    # design.py: Q_ty is (heads, S_q_pad, d), KV_ty is (num_KV_heads, S_kv_pad * d).
     pad = op._calculate_seq_padding(seq_len, num_pipelines)
     kv_heads = num_kv_heads if num_kv_heads else num_heads
     assert q == num_heads * pad * dim


### PR DESCRIPTION
`design.py` declares Q and O as `(heads, S_q_pad, d)` but K and V as
`(num_KV_heads, S_kv_pad * d)`. `get_arg_spec()` sized all four from `num_heads`, so
under GQA the K/V specs are over by `num_heads / num_KV_heads`. On the GQA param
already in `test.py` (`seq_len=16384, d=64, heads=8, pipelines=8, kv_heads=2`) that is
8388608 against 2097152, a factor of 4.

Two things kept it hidden. `num_kv_heads=0` normalizes to `heads` in `design.py`, which
makes the old formula accidentally correct for standard MHA, and `run_test` reads only
`spec.direction`, taking input buffers from the supplied tensor rather than from
`spec.shape`. So nothing consults the wrong value today. It surfaces inside an
`OperatorSequence`, where `compilation/sequence.py` asserts the MLIR arg count equals
the one computed here.

## Added
- `iron/operators/mha/test.py`: `test_arg_spec_matches_design_shapes`, covering GQA and
  standard MHA. It asserts against the shapes `design.py` declares rather than against
  literals, so it fails if either side drifts. Device-free, and deliberately not reusing
  `get_params()` -- the GQA case there is marked `extensive`, which is half of why this
  went unnoticed.

## Changed
- `iron/operators/mha/op.py`: `get_arg_spec()` sizes Q/O from `num_heads` and K/V from
  `num_KV_heads`, applying the same `0 -> num_heads` normalization `design.py` does.

## Removed
-

## Known limitation
`_calculate_seq_padding` hardcodes the block size to 64, while `design.py` derives
`S_q_pad` and `S_kv_pad` from `B_q` and `B_kv` separately. That is correct today only
because both default to 64 and `op.py` never overrides them, and `__post_init__` sets
`self.B_q`/`self.B_kv` which the helper ignores. Left alone here to keep this to one
defect.
