### PR TITLE
Allow use of MemCopy in an OperatorSequence

### DIFF
--- a/iron/operators/mem_copy/design.py
+++ b/iron/operators/mem_copy/design.py
@@ -165,14 +165,7 @@ def create_partial_workload_config(
 
 
 def my_mem_copy(
-    dev,
-    size,
-    num_cores,
-    num_channels,
-    bypass,
-    tile_size,
-    trace_size,
-    func_prefix=""
+    dev, size, num_cores, num_channels, bypass, tile_size, trace_size, func_prefix=""
 ):
     # --------------------------------------------------------------------------
     # Configuration

--- a/iron/operators/mem_copy/design.py
+++ b/iron/operators/mem_copy/design.py
@@ -172,6 +172,7 @@ def my_mem_copy(
     bypass,
     tile_size,
     trace_size,
+    func_prefix=""
 ):
     # --------------------------------------------------------------------------
     # Configuration
@@ -207,8 +208,8 @@ def my_mem_copy(
 
         # External, binary kernel definition
         mem_copy_fcn = Kernel(
-            "passThroughLine",
-            "mem_copy.o",
+            f"{func_prefix}passThroughLine",
+            f"{func_prefix}mem_copy.o",
             [line_type, line_type, np.int32],
         )
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

Describe the intent of your PR here.

## Added
- Support for using the `MemCopy` operator in an `OperatorSequence`

## Changed
- `my_mem_copy` now has the `func_prefix` parameter which defaults to an empty string.

## Removed
- Nothing.

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR has been reviewed and approved.
3. [x] All checks are passing.
