### PR TITLE
operators: propagate dtype into AIERuntimeArgSpec

### DIFF
--- a/iron/operators/gemm/op.py
+++ b/iron/operators/gemm/op.py
@@ -15,6 +15,7 @@ from iron.common import (
     DesignGenerator,
 )
 from iron.common.device_utils import get_kernel_dir
+from aie.iron import str_to_dtype
 import aie.utils as aie_utils
 
 
@@ -150,13 +151,19 @@ class GEMM(MLIROperator):
         ]
 
     def get_arg_spec(self):
+        dtype_in = str_to_dtype(self.dtype_in)
+        dtype_out = str_to_dtype(self.dtype_out)
         return [
-            AIERuntimeArgSpec("in", (self.M, self.K)),  # input A
+            AIERuntimeArgSpec("in", (self.M, self.K), dtype=dtype_in),  # input A
             AIERuntimeArgSpec(
-                "in", (self.K, self.N) if not self.b_col_maj else (self.N, self.K)
+                "in",
+                (self.K, self.N) if not self.b_col_maj else (self.N, self.K),
+                dtype=dtype_in,
             ),  # input B (weights)
             AIERuntimeArgSpec(
-                "out", (self.M, self.N) if not self.c_col_maj else (self.N, self.M)
+                "out",
+                (self.M, self.N) if not self.c_col_maj else (self.N, self.M),
+                dtype=dtype_out,
             ),  # output C
         ]
 

--- a/iron/operators/repeat/op.py
+++ b/iron/operators/repeat/op.py
@@ -56,8 +56,10 @@ class Repeat(MLIROperator):
 
     def get_arg_spec(self):
         return [
-            AIERuntimeArgSpec("in", (self.rows, self.cols)),
-            AIERuntimeArgSpec("out", (self.rows * self.repeat, self.cols)),
+            AIERuntimeArgSpec("in", (self.rows, self.cols), dtype=self.dtype),
+            AIERuntimeArgSpec(
+                "out", (self.rows * self.repeat, self.cols), dtype=self.dtype
+            ),
         ]
 
     def reference(self, x):

--- a/iron/operators/strided_copy/op.py
+++ b/iron/operators/strided_copy/op.py
@@ -95,6 +95,6 @@ class StridedCopy(MLIROperator):
 
     def get_arg_spec(self):
         return [
-            AIERuntimeArgSpec("in", (int(self.input_buffer_size),)),
-            AIERuntimeArgSpec("out", (int(self.output_buffer_size),)),
+            AIERuntimeArgSpec("in", (int(self.input_buffer_size),), dtype=self.dtype),
+            AIERuntimeArgSpec("out", (int(self.output_buffer_size),), dtype=self.dtype),
         ]

--- a/iron/tests/common/arg_spec_dtype.py
+++ b/iron/tests/common/arg_spec_dtype.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``AIERuntimeArgSpec.dtype`` must describe the operator it belongs to.
+
+``get_arg_spec()`` is the contract every buffer-sizing caller trusts:
+``iron.common.test_utils.run_test`` sizes an "out" ``XRTTensor`` off
+``spec.dtype`` (``XRTTensor(spec.shape, dtype=spec.dtype)``), and
+``OperatorSequence.calculate_buffer_layout`` sizes every dispatch buffer off
+``np.dtype(spec.dtype).itemsize``. An operator that declares its own dtype but
+never passes it into ``AIERuntimeArgSpec`` silently hands both callers the
+dataclass default (bfloat16) instead, so a non-default-dtype user under- or
+over-allocates. These tests pin the arg spec to the operator's real dtype
+directly, and pin the two callers' byte arithmetic against it -- entirely
+device-free, no ``XRTTensor``/``pyxrt`` construction anywhere below.
+"""
+
+import numpy as np
+from ml_dtypes import bfloat16
+from aie.iron import str_to_dtype
+
+from iron.common.sequence import OperatorSequence
+from iron.operators.strided_copy.op import StridedCopy
+from iron.operators.repeat.op import Repeat
+from iron.operators.gemm.op import GEMM
+
+
+def _bytes_for(shape, dtype):
+    return int(np.prod(shape) * np.dtype(dtype).itemsize)
+
+
+def test_strided_copy_arg_spec_reports_operator_dtype():
+    op = StridedCopy(
+        input_sizes=[1024],
+        input_strides=[1],
+        input_offset=0,
+        output_sizes=[1024],
+        output_strides=[1],
+        output_offset=0,
+        input_buffer_size=1024,
+        output_buffer_size=1024,
+        dtype=np.float32,
+    )
+    in_spec, out_spec = op.get_arg_spec()
+    assert in_spec.dtype == np.float32
+    assert out_spec.dtype == np.float32
+
+
+def test_repeat_arg_spec_reports_operator_dtype():
+    op = Repeat(rows=8, cols=64, repeat=4, dtype=np.int32)
+    in_spec, out_spec = op.get_arg_spec()
+    assert in_spec.dtype == np.int32
+    assert out_spec.dtype == np.int32
+
+
+def test_gemm_arg_spec_reports_operator_dtype():
+    op = GEMM(
+        M=256,
+        K=64,
+        N=64,
+        tile_m=64,
+        tile_k=64,
+        tile_n=64,
+        num_aie_columns=1,
+        dtype_in="i8",
+        dtype_out="i32",
+    )
+    a_spec, b_spec, c_spec = op.get_arg_spec()
+    assert a_spec.dtype == str_to_dtype("i8")
+    assert b_spec.dtype == str_to_dtype("i8")
+    assert c_spec.dtype == str_to_dtype("i32")
+
+
+def test_default_dtype_arg_spec_is_unaffected():
+    """The bf16-default path every shipped caller uses today must not move."""
+    op = StridedCopy(
+        input_sizes=[64],
+        input_strides=[1],
+        input_offset=0,
+        output_sizes=[64],
+        output_strides=[1],
+        output_offset=0,
+        input_buffer_size=64,
+        output_buffer_size=64,
+    )
+    in_spec, out_spec = op.get_arg_spec()
+    assert in_spec.dtype == bfloat16
+    assert out_spec.dtype == bfloat16
+
+
+def test_sequence_calculate_buffer_layout_sizes_off_the_real_dtype():
+    """``sequence.py``'s consumer (``sequence.py:399-401``): the byte length it
+    computes for a dispatch buffer must match what the design actually DMAs,
+    not a bf16-assumed width."""
+    op = GEMM(
+        M=256,
+        K=64,
+        N=64,
+        tile_m=64,
+        tile_k=64,
+        tile_n=64,
+        num_aie_columns=1,
+        dtype_in="i8",
+        dtype_out="i32",
+    )
+    seq = OperatorSequence(
+        "argspec_probe",
+        runlist=[(op, "A", "B", "C")],
+        input_args=["A", "B"],
+        output_args=["C"],
+    )
+    _, buffer_sizes, _ = seq.calculate_buffer_layout()
+    _, output_buffer_size, _ = buffer_sizes
+    assert output_buffer_size == _bytes_for((256, 64), str_to_dtype("i32"))
+
+
+def test_test_utils_xrttensor_sizing_formula_matches_the_real_dtype():
+    """``test_utils.py``'s consumer (``test_utils.py:188``,
+    ``XRTTensor(spec.shape, dtype=spec.dtype)``): replicate the exact byte
+    formula ``XRTTensor.__init__`` uses (``np.prod(shape) * itemsize(dtype)``)
+    off the arg spec alone, so the assertion holds without opening a device."""
+    op = Repeat(rows=8, cols=64, repeat=4, dtype=np.int32)
+    _, out_spec = op.get_arg_spec()
+    declared_bytes = _bytes_for(out_spec.shape, out_spec.dtype)
+    actual_bytes = _bytes_for(out_spec.shape, op.dtype)
+    assert declared_bytes == actual_bytes


### PR DESCRIPTION
## Problem

`AIERuntimeArgSpec.dtype` defaults to `bfloat16`, and none of the three `get_arg_spec()` implementations pass `dtype=`. So the spec reports bf16 regardless of what the design actually moves.

Concretely, `GEMM(dtype_in='i8', dtype_out='i32')` reports its C arg spec as bfloat16 -- **32768 bytes** -- while the design DMAs int32, **65536 bytes**. A caller sizing a host buffer from the spec under-allocates by 2x. The same 2x applies to `StridedCopy` and `Repeat` with a non-default dtype.

Two in-tree consumers size buffers off that value: `test_utils.py`'s `XRTTensor` sizing and `sequence.py`'s `calculate_buffer_layout`.

The defect is **latent today** -- a grep of every constructor call site in `iron/` shows nothing currently passes a non-default dtype -- so this is a landmine rather than a live failure.

## Fix

Pass the dtype through at the 7 call sites across 3 operator files: `dtype=self.dtype` for `strided_copy` and `repeat`, `dtype=str_to_dtype(self.dtype_in/out)` for `gemm`.

The two supporting commits are what the new test needs: `comparison.py` gains a strict comparison so exact equality is expressible, and `conftest.py` no longer aborts the whole session on an unparametrized test.

## Test

New `iron/tests/common/arg_spec_dtype.py`, 6 device-free cases.

Verified red-then-green by hand rather than only after: **5 of 6 fail before the change, 6 of 6 pass after.** (Run by importing the module and calling the test functions directly -- `conftest.py` resolves the device at collection time, so even `pytest --collect-only` would open the NPU.)

Both consumers confirmed to compute correct byte counts after the fix, and the change is a byte-for-byte no-op on every in-tree caller's default-dtype path.

`black` clean.

## Known limitation

`pr/strided-copy-transfer-size` also rewrites `get_arg_spec()` for an unrelated shape bug. Whichever lands second will need a small reconcile.