### PR TITLE
Bind MHA compile to get_current_device, not DefaultNPURuntime.

### DIFF
--- a/iron/operators/mha/op.py
+++ b/iron/operators/mha/op.py
@@ -50,7 +50,7 @@ class MHA(MLIROperator):
                 "fused_mha",
                 (),
                 {
-                    "dev": aie_utils.DefaultNPURuntime.device(),
+                    "dev": aie_utils.get_current_device(),
                     "heads": self.num_heads,
                     "S_q": self.seq_len,
                     "S_kv": self.seq_len,


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

MHA was the only operator that took the compile-time device from `DefaultNPURuntime.device()`. That is the host dispatch object, not the bound target: under `IRON_RUNTIME=cpu` it is `None`, so offline compile (`set_current_device(NPU2())` then generate MLIR) raises `AttributeError`. Use `aie_utils.get_current_device()` like GEMM, softmax, and the other operators.

## Added
-

## Changed
- `MHA.get_mlir_artifact()` binds `dev` from `get_current_device()`.

## Removed
-

## PR Merge Checklist
1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.