### PR TITLE
compilation: stop pinning aiecc to one thread

### DIFF
--- a/iron/common/compilation/base.py
+++ b/iron/common/compilation/base.py
@@ -556,6 +556,15 @@ def _link_build_outputs_into(work_dir: Path, build_dir: Path) -> None:
     link_files_from(build_dir / get_kernel_dir())
 
 
+# aiecc's own default. "1" here made every design's per-core compiles serial: on
+# the encoder-MHA design (24 cores) aiecc costs 7.7 s at -j1 and 6.0 s at -j0, and
+# nothing above 8 helps. Safe because -j does not change what aiecc produces --
+# measured on that design, insts.bin and all 24 per-core ELFs are byte-identical
+# between -j1 and -j16, and input_with_addresses.mlir differs only in the work-dir
+# path it embeds, which two runs at the SAME -j also differ in.
+_AIECC_DEFAULT_JOBS = "0"
+
+
 class AieccCompilationRule(CompilationRule):
     def __init__(self, use_chess=False, *args, **kwargs):
         self.use_chess = use_chess
@@ -574,7 +583,7 @@ class AieccFullElfCompilationRule(AieccCompilationRule):
             mlir_source = artifact.mlir_input
             work_dir = _aiecc_work_dir(mlir_source.filename)
             options = [
-                f"-j{os.environ.get('AIECC_JOBS', '1')}",
+                f"-j{os.environ.get('AIECC_JOBS', _AIECC_DEFAULT_JOBS)}",
                 "--expand-load-pdis",
                 "--get-scratchpad-parameters",
             ] + artifact.extra_flags
@@ -623,7 +632,7 @@ class AieccXclbinInstsCompilationRule(AieccCompilationRule):
         commands = []
         # Now we know for each mlir source if we need to generate an xclbin, an insts.bin or both for it
         for mlir_source in mlir_sources:
-            options = [f"-j{os.environ.get('AIECC_JOBS', '1')}"]
+            options = [f"-j{os.environ.get('AIECC_JOBS', _AIECC_DEFAULT_JOBS)}"]
             xclbin_path = None
             insts_path = None
             do_compile_xclbin = mlir_source in mlir_sources_to_xclbins


### PR DESCRIPTION
## Problem

Both aiecc rules default `AIECC_JOBS` to `1`:

```python
options = [f"-j{os.environ.get('AIECC_JOBS', '1')}"]
```

so every design's per-core compiles run one at a time, whatever the machine has. aiecc's own default
is auto-detect, and nothing here explains the override.

## Fix

Default to `0`, which is aiecc's auto-detect. The environment variable still overrides, so anyone who
wants one thread keeps it.

## Test

On a 24-core design (`StaticMHA`, 20 heads, 8 pipelines): aiecc goes from **7.7 s to 6.0 s**. Nothing
above 8 threads helps.

`-j` does not change what aiecc produces, so this is safe rather than a trade: `insts.bin` and all 24
per-core ELFs are **byte-identical between `-j1` and `-j16`**, and `input_with_addresses.mlir` differs
only in the work-dir path it embeds — which two runs at the *same* `-j` also differ in.
