### PR TITLE
gemm: check tile sizes against the kernel's divisibility rule, not a bound

### DIFF
--- a/iron/operators/gemm/op.py
+++ b/iron/operators/gemm/op.py
@@ -62,16 +62,33 @@ class GEMM(MLIROperator):
         if self.N % min_N != 0:
             raise ValueError(f"N ({self.N}) must be a multiple of {min_N}")
 
+        # r, s, t are the aie::mmul tile dims the bf16 kernel is built from
+        # (aie_kernels/aie2p/mm.cc, matmul_vectorized_2x2_mmul): it expands A
+        # and B 2x in m and n, so the static_asserts there require
+        # m % (2*r) == 0, k % s == 0, n % (2*t) == 0 -- a divisibility rule,
+        # not a lower bound. A tile_m/tile_n that merely meets the old ">="
+        # check (e.g. 8 or 12) passes here and then fails that static_assert
+        # at kernel compile time, in a file this class never names.
         if self.emulate_bf16_mmul_with_bfp16:
-            min_tile_m, min_tile_k, min_tile_n = 8, 8, 8
+            r, s, t = 8, 8, 8
         else:
-            min_tile_m, min_tile_k, min_tile_n = 4, 8, 8
-        if self.tile_m < min_tile_m:
-            raise ValueError(f"tile_m ({self.tile_m}) must be >= {min_tile_m}")
-        if self.tile_k < min_tile_k:
-            raise ValueError(f"tile_k ({self.tile_k}) must be >= {min_tile_k}")
-        if self.tile_n < min_tile_n:
-            raise ValueError(f"tile_n ({self.tile_n}) must be >= {min_tile_n}")
+            r, s, t = 4, 8, 8
+        min_tile_m, min_tile_k, min_tile_n = 2 * r, s, 2 * t
+        if self.tile_m % min_tile_m != 0:
+            raise ValueError(
+                f"tile_m ({self.tile_m}) must be a multiple of {min_tile_m} "
+                f"(aie_kernels/aie2p/mm.cc requires m % (2*r) == 0, r={r})"
+            )
+        if self.tile_k % min_tile_k != 0:
+            raise ValueError(
+                f"tile_k ({self.tile_k}) must be a multiple of {min_tile_k} "
+                f"(aie_kernels/aie2p/mm.cc requires k % s == 0, s={s})"
+            )
+        if self.tile_n % min_tile_n != 0:
+            raise ValueError(
+                f"tile_n ({self.tile_n}) must be a multiple of {min_tile_n} "
+                f"(aie_kernels/aie2p/mm.cc requires n % (2*t) == 0, t={t})"
+            )
 
         MLIROperator.__init__(self, context=self.context)
 

--- a/iron/operators/gemm/op.py
+++ b/iron/operators/gemm/op.py
@@ -63,12 +63,7 @@ class GEMM(MLIROperator):
             raise ValueError(f"N ({self.N}) must be a multiple of {min_N}")
 
         # r, s, t are the aie::mmul tile dims the bf16 kernel is built from
-        # (aie_kernels/aie2p/mm.cc, matmul_vectorized_2x2_mmul): it expands A
-        # and B 2x in m and n, so the static_asserts there require
-        # m % (2*r) == 0, k % s == 0, n % (2*t) == 0 -- a divisibility rule,
-        # not a lower bound. A tile_m/tile_n that merely meets the old ">="
-        # check (e.g. 8 or 12) passes here and then fails that static_assert
-        # at kernel compile time, in a file this class never names.
+        # (aie_kernels/aie2p/mm.cc, matmul_vectorized_2x2_mmul)
         if self.emulate_bf16_mmul_with_bfp16:
             r, s, t = 8, 8, 8
         else:

--- a/iron/tests/operators/gemm_tile_divisibility.py
+++ b/iron/tests/operators/gemm_tile_divisibility.py
@@ -2,20 +2,14 @@
 # SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""GEMM.__post_init__ must reject tile sizes the kernel cannot build, not just
-undersized ones.
+"""GEMM.__post_init__ must reject tile sizes the kernel cannot build.
 
 aie_kernels/aie2p/mm.cc's matmul_vectorized_*x*x*_bf16_* wrappers static_assert
-m % (2*r) == 0 and n % (2*t) == 0 for the (r, t) pair selected by
-emulate_bf16_mmul_with_bfp16 (r=t=8 when enabled, the default; r=4, t=8
-otherwise) -- both tile_m and tile_n are affected, in both regimes. The
-previous check only asserted tile_m/tile_k/tile_n >= a minimum, which admits
-e.g. tile_m=8 under emulation (needs a multiple of 16) or tile_m=4 without it
-(needs a multiple of 8) -- GEMM(...) constructs without error and fails a C++
-static_assert at kernel compile time, from a file this class never names.
-tile_k is genuinely undoubled (k % s == 0, s=8 in both regimes), so its old
-`>= 8` bound was already correct; it is included here for the same divisor,
-expressed the same way as tile_m/tile_n.
+m % (2*r) == 0, k % s == 0 and n % (2*t) == 0 for the (r, s, t) triple selected
+by emulate_bf16_mmul_with_bfp16 (r=t=8 when enabled, the default; r=4, t=8
+otherwise). A tile size that meets a lower bound without dividing evenly
+constructs here without error and then fails that static_assert at kernel
+compile time, from a file this class never names.
 """
 
 import pytest
@@ -36,9 +30,9 @@ def _construct(tile_m=64, tile_k=64, tile_n=64, emulate_bf16_mmul_with_bfp16=Tru
     )
 
 
-def test_tile_m_that_only_satisfies_the_old_greater_equal_check_is_rejected():
-    """tile_m=8 is >= the old min_tile_m of 8, but mm.cc needs m % 16 == 0
-    under the default emulate_bf16_mmul_with_bfp16=True (r=8)."""
+def test_tile_m_not_a_multiple_of_16_is_rejected_under_emulation():
+    """mm.cc needs m % 16 == 0 under the default emulate_bf16_mmul_with_bfp16
+    (r=8), which tile_m=8 satisfies as a bound but not as a divisor."""
     with pytest.raises(ValueError, match="tile_m .* multiple of 16"):
         _construct(tile_m=8)
 
@@ -61,15 +55,15 @@ def test_tile_n_not_a_multiple_of_16_is_rejected_regardless_of_emulation():
         _construct(tile_n=8, emulate_bf16_mmul_with_bfp16=True)
 
 
-def test_tile_m_that_only_satisfies_the_old_check_is_rejected_without_emulation():
-    """tile_m=4 is >= the old min_tile_m of 4 for this branch, but mm.cc
-    needs m % 8 == 0 without emulation (r=4)."""
+def test_tile_m_not_a_multiple_of_8_is_rejected_without_emulation():
+    """mm.cc needs m % 8 == 0 without emulation (r=4), which tile_m=4
+    satisfies as a bound but not as a divisor."""
     with pytest.raises(ValueError, match="tile_m .* multiple of 8"):
         _construct(tile_m=4, emulate_bf16_mmul_with_bfp16=False)
 
 
 def test_tile_k_not_a_multiple_of_8_is_rejected():
     # tile_k=4 still divides K=512 evenly (the outer K % tile_k check), so
-    # this exercises the new s-divisibility check rather than that one.
+    # this exercises the s-divisibility check rather than that one.
     with pytest.raises(ValueError, match="tile_k .* multiple of 8"):
         _construct(tile_k=4)

--- a/iron/tests/operators/gemm_tile_divisibility.py
+++ b/iron/tests/operators/gemm_tile_divisibility.py
@@ -7,11 +7,15 @@ undersized ones.
 
 aie_kernels/aie2p/mm.cc's matmul_vectorized_*x*x*_bf16_* wrappers static_assert
 m % (2*r) == 0 and n % (2*t) == 0 for the (r, t) pair selected by
-emulate_bf16_mmul_with_bfp16 (8/8 when enabled, the default; 4/8 otherwise).
-The previous check only asserted tile_m/tile_k/tile_n >= a minimum, which
-admits e.g. tile_m=8 under emulation even though the kernel requires a
-multiple of 16 -- GEMM(...) constructs without error and fails a C++
+emulate_bf16_mmul_with_bfp16 (r=t=8 when enabled, the default; r=4, t=8
+otherwise) -- both tile_m and tile_n are affected, in both regimes. The
+previous check only asserted tile_m/tile_k/tile_n >= a minimum, which admits
+e.g. tile_m=8 under emulation (needs a multiple of 16) or tile_m=4 without it
+(needs a multiple of 8) -- GEMM(...) constructs without error and fails a C++
 static_assert at kernel compile time, from a file this class never names.
+tile_k is genuinely undoubled (k % s == 0, s=8 in both regimes), so its old
+`>= 8` bound was already correct; it is included here for the same divisor,
+expressed the same way as tile_m/tile_n.
 """
 
 import pytest
@@ -53,6 +57,15 @@ def test_tile_n_not_a_multiple_of_16_is_rejected_regardless_of_emulation():
     """t=8 for both emulation settings, so n % 16 == 0 always."""
     with pytest.raises(ValueError, match="tile_n .* multiple of 16"):
         _construct(tile_n=8, emulate_bf16_mmul_with_bfp16=False)
+    with pytest.raises(ValueError, match="tile_n .* multiple of 16"):
+        _construct(tile_n=8, emulate_bf16_mmul_with_bfp16=True)
+
+
+def test_tile_m_that_only_satisfies_the_old_check_is_rejected_without_emulation():
+    """tile_m=4 is >= the old min_tile_m of 4 for this branch, but mm.cc
+    needs m % 8 == 0 without emulation (r=4)."""
+    with pytest.raises(ValueError, match="tile_m .* multiple of 8"):
+        _construct(tile_m=4, emulate_bf16_mmul_with_bfp16=False)
 
 
 def test_tile_k_not_a_multiple_of_8_is_rejected():

--- a/iron/tests/operators/gemm_tile_divisibility.py
+++ b/iron/tests/operators/gemm_tile_divisibility.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GEMM.__post_init__ must reject tile sizes the kernel cannot build, not just
+undersized ones.
+
+aie_kernels/aie2p/mm.cc's matmul_vectorized_*x*x*_bf16_* wrappers static_assert
+m % (2*r) == 0 and n % (2*t) == 0 for the (r, t) pair selected by
+emulate_bf16_mmul_with_bfp16 (8/8 when enabled, the default; 4/8 otherwise).
+The previous check only asserted tile_m/tile_k/tile_n >= a minimum, which
+admits e.g. tile_m=8 under emulation even though the kernel requires a
+multiple of 16 -- GEMM(...) constructs without error and fails a C++
+static_assert at kernel compile time, from a file this class never names.
+"""
+
+import pytest
+
+from iron.operators.gemm.op import GEMM
+
+
+def _construct(tile_m=64, tile_k=64, tile_n=64, emulate_bf16_mmul_with_bfp16=True):
+    return GEMM(
+        M=512,
+        K=512,
+        N=512,
+        tile_m=tile_m,
+        tile_k=tile_k,
+        tile_n=tile_n,
+        emulate_bf16_mmul_with_bfp16=emulate_bf16_mmul_with_bfp16,
+        context=None,
+    )
+
+
+def test_tile_m_that_only_satisfies_the_old_greater_equal_check_is_rejected():
+    """tile_m=8 is >= the old min_tile_m of 8, but mm.cc needs m % 16 == 0
+    under the default emulate_bf16_mmul_with_bfp16=True (r=8)."""
+    with pytest.raises(ValueError, match="tile_m .* multiple of 16"):
+        _construct(tile_m=8)
+
+
+def test_tile_m_multiple_of_16_is_accepted_under_emulation():
+    _construct(tile_m=16)
+    _construct(tile_m=64)
+
+
+def test_tile_m_multiple_of_8_is_accepted_without_emulation():
+    """r=4 without emulation, so the requirement relaxes to a multiple of 8."""
+    _construct(tile_m=8, emulate_bf16_mmul_with_bfp16=False)
+
+
+def test_tile_n_not_a_multiple_of_16_is_rejected_regardless_of_emulation():
+    """t=8 for both emulation settings, so n % 16 == 0 always."""
+    with pytest.raises(ValueError, match="tile_n .* multiple of 16"):
+        _construct(tile_n=8, emulate_bf16_mmul_with_bfp16=False)
+
+
+def test_tile_k_not_a_multiple_of_8_is_rejected():
+    # tile_k=4 still divides K=512 evenly (the outer K % tile_k check), so
+    # this exercises the new s-divisibility check rather than that one.
+    with pytest.raises(ValueError, match="tile_k .* multiple of 8"):
+        _construct(tile_k=4)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

`GEMM.__post_init__` checks `tile_m`, `tile_k`, `tile_n` against a minimum with `>=`, but `aie_kernels/aie2p/mm.cc`'s `matmul_vectorized_*_bf16_*` kernels `static_assert(m % (2*r) == 0)` and `static_assert(n % (2*t) == 0)` for the `(r, t)` pair `emulate_bf16_mmul_with_bfp16` selects (`r=t=8` when enabled, the default; `r=4, t=8` otherwise) -- a divisibility rule, not a lower bound. Both `tile_m` and `tile_n` are affected, in both regimes: `tile_m=8` passes the old check under the default emulation but needs a multiple of 16; `tile_m=4` passes it without emulation but needs a multiple of 8. `GEMM(tile_m=8, emulate_bf16_mmul_with_bfp16=True, ...)` constructs without error and fails the static_assert at kernel compile time, in a file this class never names. `tile_k` is the one dimension `matmul_vectorized_2x2_mmul` does not expand, so its rule is `k % s == 0` with `s=8` in both regimes. That is still a divisibility rule rather than a bound, so this does tighten `tile_k` as well: `tile_k=12` passed the old `>= 8` check and is now rejected, correctly -- `mm.cc` would have refused it.

The existing test suite doesn't cover this: `test.py` hardcodes `emulate_bf16_mmul_with_bfp16=False`, and its one `tile_m=8` case (`extensive_params`, `M=2048,K=2048,N=2048,m=8,k=16,n=32`) only survives because `2*r == 8` in that branch -- the default-emulation boundary was untested.

## Added
- `iron/tests/operators/gemm_tile_divisibility.py`: construction-only tests (no device, no MLIR generation) covering both `tile_m` and `tile_n` under both `emulate_bf16_mmul_with_bfp16` settings, plus `tile_k`.

## Changed
- `iron/operators/gemm/op.py`: `__post_init__` now checks `tile_m % (2*r) == 0`, `tile_k % s == 0`, `tile_n % (2*t) == 0` instead of `>=`, and the error message names the required multiple and the source file.

## Removed
-

## Known gap
`design.py`'s own guard (`if not use_scalar: assert m % r == 0; assert n % t == 0`) is a second, independently-too-weak check -- it's missing the same `2*` factor, and `use_scalar` doesn't gate it out: the `extern "C"` block always emits both the scalar and vectorized symbols (`combos(matmul_vectorized_c_func) combos(matmul_scalar_c_func) ...`), so the vectorized static_assert fires at compile time even for a scalar-only build. Not fixed here since `GEMM` (this PR's scope) always calls `design.py` with already-validated tiles; a direct `design.py` CLI/API caller is still exposed.

## Evidence
```
$ PYTHONPATH=. python3 -m pytest --noconftest iron/tests/operators/gemm_tile_divisibility.py -v
======================== test session starts ========================
collected 6 items

gemm_tile_divisibility.py::test_tile_m_that_only_satisfies_the_old_greater_equal_check_is_rejected PASSED
gemm_tile_divisibility.py::test_tile_m_multiple_of_16_is_accepted_under_emulation PASSED
gemm_tile_divisibility.py::test_tile_m_multiple_of_8_is_accepted_without_emulation PASSED
gemm_tile_divisibility.py::test_tile_n_not_a_multiple_of_16_is_rejected_regardless_of_emulation PASSED
gemm_tile_divisibility.py::test_tile_m_that_only_satisfies_the_old_check_is_rejected_without_emulation PASSED
gemm_tile_divisibility.py::test_tile_k_not_a_multiple_of_8_is_rejected PASSED

======================== 6 passed in 0.29s ========================
```
Ran with `--noconftest`: this repo's root `conftest.py` opens the NPU unconditionally at collection time (see the companion PR fixing that), which this change has nothing to do with, so it's bypassed here rather than exercised.

Confirmed the defect against unmodified `devel` (`deb6e1e7`) before writing the fix: `GEMM(M=512, K=512, N=512, tile_m=8, tile_k=64, tile_n=64, emulate_bf16_mmul_with_bfp16=True, context=None)` constructs with no error.

## PR Merge Checklist

1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
