### PR TITLE
swiglu_prefill: the padding comment has been stale since #76

### DIFF
--- a/iron/operators/swiglu_prefill/op.py
+++ b/iron/operators/swiglu_prefill/op.py
@@ -27,8 +27,8 @@ class SwiGLUPrefill(OperatorSequence):
         self.embedding_dim = embedding_dim
         self.prio_accuracy = prio_accuracy
 
-        # GEMM, SiLU, ElementwiseMul require input shapes that meet hardware 
-        # alignment requirements (e.g. GEMM needs M % (tile_m * 4) == 0). We 
+        # GEMM, SiLU, ElementwiseMul require input shapes that meet hardware
+        # alignment requirements (e.g. GEMM needs M % (tile_m * 4) == 0). We
         # read the dims back off gemm_1 only to size SiLU/ElementwiseMul
         # from the same source GEMM validated, not because they differ.
         accuracy_flags = {}

--- a/iron/operators/swiglu_prefill/op.py
+++ b/iron/operators/swiglu_prefill/op.py
@@ -27,12 +27,9 @@ class SwiGLUPrefill(OperatorSequence):
         self.embedding_dim = embedding_dim
         self.prio_accuracy = prio_accuracy
 
-        # None of GEMM, SiLU, ElementwiseMul pad: each raises ValueError in
-        # __post_init__ if its shape doesn't already meet hardware alignment
-        # requirements (e.g. GEMM needs M % (tile_m * 4) == 0). So seq_len,
-        # embedding_dim and hidden_dim must already be aligned, or
-        # construction fails below. We read the dims back off gemm_1 (rather
-        # than reusing self.seq_len etc.) only to size SiLU/ElementwiseMul
+        # GEMM, SiLU, ElementwiseMul require input shapes that meet hardware 
+        # alignment requirements (e.g. GEMM needs M % (tile_m * 4) == 0). We 
+        # read the dims back off gemm_1 only to size SiLU/ElementwiseMul
         # from the same source GEMM validated, not because they differ.
         accuracy_flags = {}
         if self.prio_accuracy:

--- a/iron/operators/swiglu_prefill/op.py
+++ b/iron/operators/swiglu_prefill/op.py
@@ -27,9 +27,13 @@ class SwiGLUPrefill(OperatorSequence):
         self.embedding_dim = embedding_dim
         self.prio_accuracy = prio_accuracy
 
-        # All operators (GEMM, SiLU, ElementwiseMul) apply their own padding
-        # to meet hardware alignment requirements. We store the padded dimensions
-        # from GEMM and size SiLU/ElementwiseMul to match.
+        # None of GEMM, SiLU, ElementwiseMul pad: each raises ValueError in
+        # __post_init__ if its shape doesn't already meet hardware alignment
+        # requirements (e.g. GEMM needs M % (tile_m * 4) == 0). So seq_len,
+        # embedding_dim and hidden_dim must already be aligned, or
+        # construction fails below. We read the dims back off gemm_1 (rather
+        # than reusing self.seq_len etc.) only to size SiLU/ElementwiseMul
+        # from the same source GEMM validated, not because they differ.
         accuracy_flags = {}
         if self.prio_accuracy:
             accuracy_flags = {
@@ -48,19 +52,19 @@ class SwiGLUPrefill(OperatorSequence):
             num_aie_columns=n_cols,
             **accuracy_flags,
         )
-        self.seq_len_padded = gemm_1.M
-        self.embedding_dim_padded = gemm_1.K
-        self.hidden_dim_padded = gemm_1.N
+        self.seq_len_aligned = gemm_1.M
+        self.embedding_dim_aligned = gemm_1.K
+        self.hidden_dim_aligned = gemm_1.N
 
         silu = SiLU(
-            size=self.seq_len_padded * self.hidden_dim_padded,
+            size=self.seq_len_aligned * self.hidden_dim_aligned,
             num_aie_columns=n_cols,
-            tile_size=self.hidden_dim_padded // n_cols,
+            tile_size=self.hidden_dim_aligned // n_cols,
         )
         eltwise_mul = ElementwiseMul(
-            size=self.seq_len_padded * self.hidden_dim_padded,
+            size=self.seq_len_aligned * self.hidden_dim_aligned,
             num_aie_columns=n_cols,
-            tile_size=self.hidden_dim_padded // n_cols,
+            tile_size=self.hidden_dim_aligned // n_cols,
         )
         gemm_2 = GEMM(
             M=self.seq_len,

--- a/iron/tests/operators/swiglu_prefill_no_padding.py
+++ b/iron/tests/operators/swiglu_prefill_no_padding.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SwiGLUPrefill does not pad: it raises for a seq_len its inner GEMM cannot
+tile, and the *_aligned attributes just echo the input dims back.
+
+The __init__ docstring used to claim "All operators (GEMM, SiLU,
+ElementwiseMul) apply their own padding", but none of the three pad --
+each raises ValueError from __post_init__ if its shape doesn't already
+divide evenly (see iron/common/operator_bases.py and
+iron/operators/gemm/op.py). So SwiGLUPrefill(seq_len=...) simply forwards
+that raise for any seq_len that is not already a multiple of
+tile_m * 4 (256 with GEMM's defaults).
+"""
+
+import aie.utils as aie_utils
+import pytest
+from aie.iron.device import NPU2
+
+from iron.operators.swiglu_prefill.op import SwiGLUPrefill
+
+
+def _construct(seq_len, embedding_dim=2048, hidden_dim=2048):
+    aie_utils.set_current_device(NPU2())
+    return SwiGLUPrefill(
+        seq_len=seq_len, embedding_dim=embedding_dim, hidden_dim=hidden_dim
+    )
+
+
+def test_non_aligned_seq_len_raises_instead_of_being_padded():
+    with pytest.raises(ValueError, match=r"M \(300\) must be a multiple of 256"):
+        _construct(seq_len=300)
+
+
+def test_aligned_seq_len_constructs_and_aligned_attrs_equal_the_input():
+    op = _construct(seq_len=512)
+    assert op.seq_len_aligned == 512 == op.seq_len
+    assert op.embedding_dim_aligned == 2048 == op.embedding_dim
+    assert op.hidden_dim_aligned == 2048 == op.hidden_dim

--- a/iron/tests/operators/swiglu_prefill_no_padding.py
+++ b/iron/tests/operators/swiglu_prefill_no_padding.py
@@ -4,14 +4,6 @@
 
 """SwiGLUPrefill does not pad: it raises for a seq_len its inner GEMM cannot
 tile, and the *_aligned attributes just echo the input dims back.
-
-The __init__ docstring used to claim "All operators (GEMM, SiLU,
-ElementwiseMul) apply their own padding", but none of the three pad --
-each raises ValueError from __post_init__ if its shape doesn't already
-divide evenly (see iron/common/operator_bases.py and
-iron/operators/gemm/op.py). So SwiGLUPrefill(seq_len=...) simply forwards
-that raise for any seq_len that is not already a multiple of
-tile_m * 4 (256 with GEMM's defaults).
 """
 
 import aie.utils as aie_utils


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

`SwiGLUPrefill.__init__` says "All operators (GEMM, SiLU, ElementwiseMul) apply their own padding to meet hardware alignment requirements. We store the padded dimensions from GEMM" and then reads `self.seq_len_padded = gemm_1.M`. None of the three pad: each raises `ValueError` from its own `__post_init__` on a non-divisible shape (`iron/operators/gemm/op.py`, `iron/common/operator_bases.py`). So `gemm_1.M` is just `seq_len` unchanged, and `SwiGLUPrefill(seq_len=300, embedding_dim=2048, hidden_dim=2048)` raises `ValueError: M (300) must be a multiple of 256` instead of padding to 512 as the comment implies.

The comment was true when written (#50, 2025-12-11: GEMM really did pad then). Padding was removed in #76 (2026-03-23); #88 (2026-04-06) is the commit that made raise-only validation the norm and reworded these lines without correcting them, and #132 (2026-07-09) touched the same lines again, still describing padding. So this has been stale for about five months across two more edits, not a one-off typo.

This overlaps with #106 (open, unmerged), which hits the same root cause from the small-`seq_len` side by adding `tile_m`/`tile_k`/`tile_n` overrides so `min_M` drops below GEMM's default 256. That's a real fix for making small prefill batches reachable; this PR is narrower and just makes the comment and field names match what the code has actually done since #76 -- it doesn't touch tile overrides and shouldn't conflict with #106.

## Added
- `iron/tests/operators/swiglu_prefill_no_padding.py`: construction-only tests (no device) showing a non-aligned `seq_len` raises, and that the `*_aligned` fields equal the input dims rather than a padded value.

## Changed
- `iron/operators/swiglu_prefill/op.py`: corrected the comment, and renamed `seq_len_padded`/`embedding_dim_padded`/`hidden_dim_padded` to `*_aligned` (no external callers of the old names).

## Removed
-

## Evidence
```
$ PYTHONPATH=. python3 -m pytest --noconftest iron/tests/operators/swiglu_prefill_no_padding.py -v
======================== test session starts ========================
collected 2 items

swiglu_prefill_no_padding.py::test_non_aligned_seq_len_raises_instead_of_being_padded PASSED
swiglu_prefill_no_padding.py::test_aligned_seq_len_constructs_and_aligned_attrs_equal_the_input PASSED

======================== 2 passed in 0.20s ========================
```
Confirmed against unmodified `devel` (`deb6e1e7`) first: `SwiGLUPrefill(seq_len=300, embedding_dim=2048, hidden_dim=2048)` raises `ValueError: M (300) must be a multiple of 256`; at `seq_len=512` it constructs with `seq_len_padded == 512`, the unchanged input.

## PR Merge Checklist

1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
