### PR TITLE
rope: make the CPU reference match the device's angle-row convention

### DIFF
--- a/iron/operators/rope/reference.py
+++ b/iron/operators/rope/reference.py
@@ -122,8 +122,10 @@ def reference(x, angles, method_type=0, rows=None, cols=None):
     dim (length ``cols``).  Only ``method_type == 0`` (TWO_HALVES) is supported
     here; the golden-data generator uses :func:`apply_rope`, which additionally
     supports the interleaved method and works from the full-precision cos/sin
-    tables.  ``angles`` may have fewer rows than ``x``; in that case the angles
-    are tiled along the row dimension to match ``x``.
+    tables.  ``angles`` may have fewer rows than ``x``; in that case each angle
+    row is repeated for ``rows / angles.shape[0]`` *consecutive* rows of ``x``,
+    matching the device kernel (design.py's ``core_body`` acquires one angle
+    row and applies it to that many consecutive input rows before moving on).
     """
     if method_type != 0:
         raise NotImplementedError(
@@ -140,8 +142,11 @@ def reference(x, angles, method_type=0, rows=None, cols=None):
     if cos.shape[0] != rows:
         if rows % cos.shape[0] == 0:
             rep = rows // cos.shape[0]
-            cos = cos.repeat(rep, 1)
-            sin = sin.repeat(rep, 1)
+            # repeat_interleave, not repeat: the device applies one angle row
+            # to `rep` *consecutive* input rows, not to `rep` tiled copies of
+            # the whole angle block (see design.py's core_body).
+            cos = cos.repeat_interleave(rep, dim=0)
+            sin = sin.repeat_interleave(rep, dim=0)
         else:
             cos = cos[:rows]
             sin = sin[:rows]

--- a/iron/operators/rope/reference.py
+++ b/iron/operators/rope/reference.py
@@ -142,9 +142,6 @@ def reference(x, angles, method_type=0, rows=None, cols=None):
     if cos.shape[0] != rows:
         if rows % cos.shape[0] == 0:
             rep = rows // cos.shape[0]
-            # repeat_interleave, not repeat: the device applies one angle row
-            # to `rep` *consecutive* input rows, not to `rep` tiled copies of
-            # the whole angle block (see design.py's core_body).
             cos = cos.repeat_interleave(rep, dim=0)
             sin = sin.repeat_interleave(rep, dim=0)
         else:

--- a/iron/tests/operators/rope_reference_convention.py
+++ b/iron/tests/operators/rope_reference_convention.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""reference() must apply an angle row to `rows / angle_rows` CONSECUTIVE
+input rows, matching the device kernel -- not to `rows / angle_rows` tiled
+copies of the whole angle block.
+
+design.py's core_body acquires one angle row and applies it to
+`tensor_rows_per_angle_row` consecutive input rows before moving to the
+next angle row: row r uses angle row `r // (rows // angle_rows)`. A prior
+version of reference() used `cos.repeat(rep, 1)`, which tiles the whole
+angle block `rep` times (row r uses angle row `r % angle_rows`) --  the
+interleaved convention. The two conventions agree only when angle_rows is
+1 or rows, so this is invisible unless something exercises
+1 < angle_rows < rows -- exactly the shape llama_npu.py's prefill RoPE uses
+(rows=prompt_len*n_heads, angle_rows=prompt_len), though nothing there
+currently calls reference() with it.
+"""
+
+import torch
+
+from iron.operators.rope.reference import reference
+
+
+def _block_major_expected(x, angles, rows, angle_rows):
+    """Ground truth built directly from the device convention: row r uses
+    angle row r // (rows // angle_rows)."""
+    cols = x.shape[-1]
+    half = cols // 2
+    tensor_rows_per_angle_row = rows // angle_rows
+    out = torch.empty(rows, cols, dtype=torch.float32)
+    for r in range(rows):
+        a = r // tensor_rows_per_angle_row
+        cos = angles[a, 0::2].to(torch.float32)
+        sin = angles[a, 1::2].to(torch.float32)
+        x1, x2 = x[r, :half].to(torch.float32), x[r, half:].to(torch.float32)
+        out[r, :half] = x1 * cos - x2 * sin
+        out[r, half:] = x2 * cos + x1 * sin
+    return out.to(torch.bfloat16)
+
+
+def _make_inputs(rows, angle_rows, cols=4, seed=0):
+    torch.manual_seed(seed)
+    half = cols // 2
+    x = torch.randn(rows, cols).to(torch.bfloat16)
+    angles = torch.zeros(angle_rows, cols, dtype=torch.bfloat16)
+    angles[:, 0::2] = torch.rand(angle_rows, half).to(torch.bfloat16)
+    angles[:, 1::2] = torch.rand(angle_rows, half).to(torch.bfloat16)
+    return x, angles
+
+
+def test_reference_matches_device_convention_for_batched_angle_rows():
+    """Decisive case: 1 < angle_rows < rows. Before the fix, 4 of these 6
+    rows disagreed with the device convention."""
+    rows, angle_rows = 6, 3
+    x, angles = _make_inputs(rows, angle_rows)
+    expected = _block_major_expected(x, angles, rows, angle_rows)
+    got = reference(x, angles, rows=rows, cols=x.shape[-1])
+    assert torch.equal(expected, got)
+
+
+def test_reference_matches_device_convention_across_shapes():
+    for rows, angle_rows in [(8, 2), (1024, 1), (4, 4), (13, 13), (12, 4)]:
+        x, angles = _make_inputs(rows, angle_rows)
+        expected = _block_major_expected(x, angles, rows, angle_rows)
+        got = reference(x, angles, rows=rows, cols=x.shape[-1])
+        assert torch.equal(expected, got), f"mismatch at rows={rows} angle_rows={angle_rows}"

--- a/iron/tests/operators/rope_reference_convention.py
+++ b/iron/tests/operators/rope_reference_convention.py
@@ -2,20 +2,15 @@
 # SPDX-FileCopyrightText: Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""reference() must apply an angle row to `rows / angle_rows` CONSECUTIVE
-input rows, matching the device kernel -- not to `rows / angle_rows` tiled
-copies of the whole angle block.
+"""reference() must match the device's angle convention: design.py's core_body
+acquires one angle row and applies it to `rows // angle_rows` consecutive input
+rows before moving to the next, so row r uses angle row
+`r // (rows // angle_rows)`.
 
-design.py's core_body acquires one angle row and applies it to
-`tensor_rows_per_angle_row` consecutive input rows before moving to the
-next angle row: row r uses angle row `r // (rows // angle_rows)`. A prior
-version of reference() used `cos.repeat(rep, 1)`, which tiles the whole
-angle block `rep` times (row r uses angle row `r % angle_rows`) --  the
-interleaved convention. The two conventions agree only when angle_rows is
-1 or rows, so this is invisible unless something exercises
-1 < angle_rows < rows -- exactly the shape llama_npu.py's prefill RoPE uses
-(rows=prompt_len*n_heads, angle_rows=prompt_len), though nothing there
-currently calls reference() with it.
+That convention and the interleaved one (`r % angle_rows`) agree whenever
+angle_rows is 1 or rows, so only 1 < angle_rows < rows tells them apart --
+the regime llama_npu.py's prefill RoPE shape sits in
+(rows=prompt_len*n_heads, angle_rows=prompt_len).
 """
 
 import torch
@@ -24,8 +19,8 @@ from iron.operators.rope.reference import reference
 
 
 def _block_major_expected(x, angles, rows, angle_rows):
-    """Ground truth built directly from the device convention: row r uses
-    angle row r // (rows // angle_rows)."""
+    """Device convention spelled out row by row: row r uses angle row
+    r // (rows // angle_rows)."""
     cols = x.shape[-1]
     half = cols // 2
     tensor_rows_per_angle_row = rows // angle_rows
@@ -51,8 +46,7 @@ def _make_inputs(rows, angle_rows, cols=4, seed=0):
 
 
 def test_reference_matches_device_convention_for_batched_angle_rows():
-    """Decisive case: 1 < angle_rows < rows. Before the fix, 4 of these 6
-    rows disagreed with the device convention."""
+    """1 < angle_rows < rows, the only regime that separates the two conventions."""
     rows, angle_rows = 6, 3
     x, angles = _make_inputs(rows, angle_rows)
     expected = _block_major_expected(x, angles, rows, angle_rows)
@@ -65,4 +59,6 @@ def test_reference_matches_device_convention_across_shapes():
         x, angles = _make_inputs(rows, angle_rows)
         expected = _block_major_expected(x, angles, rows, angle_rows)
         got = reference(x, angles, rows=rows, cols=x.shape[-1])
-        assert torch.equal(expected, got), f"mismatch at rows={rows} angle_rows={angle_rows}"
+        assert torch.equal(
+            expected, got
+        ), f"mismatch at rows={rows} angle_rows={angle_rows}"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

Fixes #188.

`reference()` used `cos.repeat(rep, 1)` to stretch an `angle_rows`-row LUT to `rows` rows, which tiles the whole block (row `r` uses angle row `r % angle_rows`). The device kernel (`design.py`'s `core_body`) applies one angle row to `rows / angle_rows` *consecutive* input rows instead (row `r` uses angle row `r // (rows / angle_rows)`). The two conventions only agree at `angle_rows` in `{1, rows}`, so this was invisible until something calls `reference()` at `1 < angle_rows < rows` -- exactly the shape `llama_npu.py`'s prefill RoPE uses (`rows=prompt_len*n_heads, angle_rows=prompt_len`), though nothing currently routes through `reference()` at that shape. `repeat_interleave` is the direct fix: it repeats each row in place instead of tiling the block.

I'm recommending the device kernel as canonical over `reference()`, not the other way around -- see the linked issue for why.

## Added
- `iron/tests/operators/rope_reference_convention.py`: builds a ground truth directly from the device's row-to-angle mapping and checks `reference()` against it across several `(rows, angle_rows)` shapes, including the decisive `1 < angle_rows < rows` case.

## Changed
- `iron/operators/rope/reference.py`: `cos.repeat(rep, 1)` / `sin.repeat(rep, 1)` -> `repeat_interleave(rep, dim=0)`, and the docstring now says which convention and why.

## Removed
-

## Evidence
```
$ PYTHONPATH=. python3 -m pytest --noconftest iron/tests/operators/rope_reference_convention.py -v
======================== test session starts ========================
collected 2 items

rope_reference_convention.py::test_reference_matches_device_convention_for_batched_angle_rows PASSED
rope_reference_convention.py::test_reference_matches_device_convention_across_shapes PASSED

======================== 2 passed in 0.89s ========================
```
Before the fix, the first test's `rows=6, angle_rows=3` case shows 4 of 6 rows mismatching the device-convention ground truth (see the linked issue for the exact numbers); after `repeat_interleave`, all shapes tested (`(6,3), (8,2), (1024,1), (4,4), (13,13), (12,4)`) match exactly.

Not touched: `generate_golden_reference()`/`apply_rope()`, which `rope/test.py` actually uses for its device-comparison golden -- that path already encodes the consecutive-row convention correctly via its `.transpose(0, 1)`, so it isn't affected by this bug and this PR doesn't change it.

## PR Merge Checklist

1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
