### PR TITLE
Add artifact fingerprinting and improve validation

### DIFF
--- a/ci/scripts/merge_all.py
+++ b/ci/scripts/merge_all.py
@@ -3,7 +3,9 @@
 # SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import argparse, csv, os
+import argparse
+import csv
+import os
 from datetime import datetime
 
 

--- a/ci/scripts/pretty_aggregate.py
+++ b/ci/scripts/pretty_aggregate.py
@@ -9,7 +9,7 @@ import argparse
 import csv
 import os
 
-from pretty_common import display_name, parse_checks, split_test_path, status_emoji
+from pretty_common import display_name, parse_checks, split_test_path
 
 parser = argparse.ArgumentParser(
     description="Aggregate CI results from all architecture subdirectories into a top-level readme.md"

--- a/conftest.py
+++ b/conftest.py
@@ -7,7 +7,6 @@ import subprocess
 from datetime import datetime
 from pathlib import Path
 import pytest
-import sys
 import statistics
 
 from iron.common import AIEContext

--- a/iron/applications/llama_3.2_1b/llama_inference_harness.py
+++ b/iron/applications/llama_3.2_1b/llama_inference_harness.py
@@ -19,7 +19,8 @@ import time
 import argparse
 
 import safetensors.torch
-import tiktoken, tiktoken.load
+import tiktoken
+import tiktoken.load
 
 # Configuration
 # ##########################################################################

--- a/iron/common/base.py
+++ b/iron/common/base.py
@@ -22,9 +22,6 @@ from .compilation import (
     CompilationArtifact,
     XclbinArtifact,
     InstsBinArtifact,
-    KernelObjectArtifact,
-    KernelArchiveArtifact,
-    SourceArtifact,
 )
 
 

--- a/iron/common/compilation/base.py
+++ b/iron/common/compilation/base.py
@@ -37,9 +37,10 @@ from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Iterator, Sequence
 from pathlib import Path
+import hashlib
+import json
 import os.path
 import shutil
-import zlib
 import logging
 import subprocess
 import importlib.util
@@ -50,6 +51,117 @@ import sys
 
 from iron.common.device_utils import get_kernel_dir
 from aie.utils.compile.utils import compile_cxx_core_function, compile_mlir_module
+
+# Global Functions
+# ##########################################################################
+
+# Data flow tier enumeration
+# ##########################################################################
+
+class DataFlowTier(Enum):
+    """Data flow tier representing precision tier for NPU execution."""
+    BFLOAT16 = "bfloat16"
+    FLOAT32 = "f32"
+
+    @property
+    def dtype(self):
+        """Return the numpy dtype for this tier."""
+        if self == DataFlowTier.BFLOAT16:
+            from ml_dtypes import bfloat16
+            return bfloat16
+        else:
+            import numpy as np
+            return np.float32
+
+    @property
+    def itemsize(self):
+        """Return the itemsize in bytes for this tier."""
+        if self == DataFlowTier.BFLOAT16:
+            return 2
+        else:
+            return 4
+
+# Toolchain version fingerprint
+# ##########################################################################
+
+_SUFFIX = ".meta"
+
+
+def _toolchain_version() -> str:
+    """A short hash of the toolchain's identifying metadata.
+
+    This is deliberately coarse-grained: it hashes the installed mlir-aie
+    Python package version plus the sizes/mtimes of the main LLVM toolchain
+    binaries. The goal is to invalidate caches when the toolchain is upgraded,
+    not to fingerprint individual binaries precisely. Cheap to compute, stable
+    while nothing changes.
+    """
+    digest = hashlib.sha256()
+    try:
+        import aie
+
+        digest.update(
+            ("mlir_aie " + (getattr(aie, "__version__", "") or "")).encode()
+        )
+    except Exception:
+        pass
+
+    # Find the tools the same way _find_tool does (peano, then mlir-aie, then PATH),
+    # but without importing config eagerly here: this helper is called inside an
+    # artifact availability check, which must not drag in the whole toolchain.
+    def _locate(name: str) -> Path | None:
+        for key, sub in (("PEANO_INSTALL_DIR", "bin"), ("root_path", "bin")):
+            try:
+                import importlib
+
+                cfg = importlib.import_module("aie.utils.config").config
+                base = getattr(cfg, key, None) if key.isupper() else getattr(cfg, key, None)
+                if isinstance(base, str) and base:
+                    p = Path(base) / sub / name
+                    if p.is_file():
+                        return p
+            except Exception:
+                continue
+        found = shutil.which(name)
+        return Path(found) if found else None
+
+    for tool in ("aie-opt", "aie-translate", "clang++", "llvm-ar"):
+        p = _locate(tool)
+        if p is None:
+            continue
+        digest.update(tool.encode())
+        try:
+            # Sizes are cheap and change almost every toolchain bump.
+            st = p.stat()
+            digest.update(str(st.st_size).encode())
+            digest.update(str(st.st_mtime_ns).encode())
+        except OSError:
+            continue
+    return digest.hexdigest()[:16]
+
+
+def _write_fingerprint_meta(
+    filename: Path, payload: Any, deps: list[tuple[str, str]]
+) -> None:
+    """Write the fingerprint sidecar for ``filename`` (atomic-ish write).
+
+    ``deps`` is a list of ``(dep_filename, dep_fingerprint)`` pairs. The
+    fingerprint must be JSON-serializable.
+    """
+    meta = {"payload": payload, "deps": [list(d) for d in deps]}
+    target = filename.with_suffix(filename.suffix + _SUFFIX)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(json.dumps(meta, sort_keys=True))
+    tmp.replace(target)
+
+
+def _read_fingerprint_meta(filename: Path) -> dict | None:
+    """Read the fingerprint sidecar for ``filename``, or None if unreadable."""
+    try:
+        return json.loads(filename.with_suffix(filename.suffix + _SUFFIX).read_text())
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+
 
 # Global Functions
 # ##########################################################################
@@ -249,6 +361,14 @@ class CompilationArtifact(ABC):
     Each artifact corresponds to exactly one file on disk.  Subclasses
     represent specific kinds of build products (source files, MLIR modules,
     kernel objects, xclbin packages, etc.).
+
+    Every artifact can produce a :meth:`fingerprint` - a stable hash of the
+    *properties of the build* that determine its output (own flags, toolchain,
+    and dependency fingerprints). Products written to disk record their
+    fingerprint in a ``.meta`` sidecar, and :meth:`is_available_in_filesystem`
+    requires it to still match, so a cached artifact is *not* reused when a
+    compile flag, a dependency, or the toolchain changes - regardless of file
+    mtimes.
     """
 
     def __init__(
@@ -273,6 +393,95 @@ class CompilationArtifact(ABC):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.filename})"
 
+    def _fingerprint_payload(self) -> Any:
+        """JSON-serializable blob identifying this artifact's *own* build inputs.
+
+        Subclasses override this to include the flags/settings that change its
+        output (``extra_flags``, ``kernel_name``, ``rename_symbols``, ...). The
+        base returns the class name and filename only. The hash recursively
+        folds in ``deps`` and the toolchain fingerprint, so this does not need
+        to be exhaustive - missing a property here only weakens (never
+        breaks) cache invalidation.
+        """
+        return {
+            "class": type(self).__name__,
+            "filename": self.filename,
+        }
+
+    def record_fingerprint(self) -> None:
+        """Write this product's ``.meta`` sidecar after it is produced.
+
+        Called by the compilation rules once the underlying file exists. The
+        sidecar stores the full recursive fingerprint (own payload + dep
+        fingerprints, each source's live content hash included), which
+        :meth:`is_available_in_filesystem` re-computes and compares. A stale
+        sidecar (flag/dependency/toolchain change) forces a rebuild.
+        """
+        deps = [
+            (dep.filename, dep.fingerprint())
+            for dep in self.dependencies
+            if isinstance(dep, CompilationArtifact)
+        ]
+        _write_fingerprint_meta(
+            Path(self.filename),
+            {
+                "fingerprint": self.fingerprint(),
+                "payload": self._fingerprint_payload(),
+                "deps": [list(d) for d in deps],
+            },
+        )
+
+    @property
+    def _uses_toolchain(self) -> bool:
+        """True for products whose content depends on the compiler toolchain.
+
+        Sources and generated-MLIR artifacts do not (the MLIR generator is
+        pure Python over the design args). Kernel objects, archives, xclbins,
+        insts.bins and ELFs all link/compile through Peano + mlir-aie, so a
+        toolchain bump must invalidate them.
+        """
+        return isinstance(
+            self,
+            (KernelObjectArtifact, KernelArchiveArtifact, XclbinArtifact, InstsBinArtifact, FullElfArtifact),
+        )
+
+    def fingerprint(self, _depth: int = 0) -> str:
+        """A stable hash of this artifact's build inputs.
+
+        Everything that determines the artifact's output is folded into one
+        string: own payload (flags, settings), dependency fingerprints
+        (recursively — source leaves contribute their *live content hash*), and
+        — for products compiled through Peano/mlir-aie — the toolchain
+        fingerprint. Editing a source or swapping the toolchain thus changes
+        this value and invalidates every downstream cached product.
+        """
+        if _depth > 64:
+            raise RecursionError(f"artifact dependency cycle at {self.filename}")
+
+        if isinstance(self, SourceArtifact):
+            # A source's content *is* its fingerprint, hashed live so edits are
+            # seen even without a rules pass.
+            digest = hashlib.sha256()
+            digest.update(type(self).__name__.encode())
+            file_hash = self._file_fingerprint()
+            digest.update(str(file_hash).encode())
+            return digest.hexdigest()
+
+        payload = self._fingerprint_payload()
+        dep_fprints = [
+            (dep.filename, dep.fingerprint(_depth + 1))
+            for dep in self.dependencies
+            if isinstance(dep, CompilationArtifact)
+        ]
+        if self._uses_toolchain:
+            payload = {"payload": payload, "toolchain": _toolchain_version()}
+        digest = hashlib.sha256()
+        digest.update(json.dumps(payload, sort_keys=True, default=str).encode())
+        for name, fprint in dep_fprints:
+            digest.update(hashlib.sha256(name.encode()).hexdigest().encode())
+            digest.update(fprint.encode())
+        return digest.hexdigest()
+
     def is_available(self) -> bool:
         """'Conceptual' availability: during a dry-run or in the planning stage, available may be True even if the underlying file does not exist yet."""
         # If any of our dependencies' dependencies are outdated, this artifact is also outdated
@@ -282,18 +491,58 @@ class CompilationArtifact(ABC):
         """Return True if all direct dependencies are available."""
         return all(d.is_available() for d in self.dependencies)
 
+    def _file_fingerprint(self) -> str | None:
+        """Hash of the on-disk file, or None if it does not exist.
+
+        Used for source artifacts, whose "fingerprint" is their content.
+        """
+        path = Path(self.filename)
+        if not path.exists() or not path.is_file():
+            return None
+        h = hashlib.sha256()
+        try:
+            with open(path, "rb") as f:
+                for chunk in iter(lambda: f.read(65536), b""):
+                    h.update(chunk)
+        except OSError:
+            return None
+        return h.hexdigest()
+
     def is_available_in_filesystem(self) -> bool:
-        """'Real' availability: checks if the underlying file exists and is up-to-date with respect to dependencies."""
-        if not Path(self.filename).exists():
+        """'Real' availability: the file exists and is up-to-date for this build.
+
+        Uptodate-ness is decided by fingerprint equality, not mtimes:
+
+        * a *source* artifact's "fingerprint" is its file content, hashed live;
+        * a *product*'s recorded ``.meta`` fingerprint must equal the one this
+          build would produce now, which recursively folds in every source's
+          content hash, own flags, and the toolchain fingerprint.
+
+        So editing a ``.cc``/``design.py``/``op.py`` source or bumping the
+        toolchain invalidates every downstream product - regardless of whether
+        a file's mtime happens to be newer. A missing sidecar (a fresh build,
+        or a cache from before this scheme) counts as stale.
+        """
+        path = Path(self.filename)
+        if not path.exists() or not path.is_file():
             return False
-        file_mtime = os.path.getmtime(self.filename)
-        for dependency in self.dependencies:
-            if (
-                not dependency.is_available_in_filesystem()
-                or os.path.getmtime(dependency.filename) > file_mtime
-            ):
-                return False
-        return True
+
+        if isinstance(self, SourceArtifact):
+            # A source is up-to-date iff its content still is what downstream
+            # fingerprints folded in. There is nothing recorded about it to
+            # compare, so it is available as long as the file exists (products
+            # that depend on it re-hash it live via fingerprint()).
+            return True
+
+        # Product: recompute the current build fingerprint and compare against
+        # the recorded one on disk.
+        recorded = _read_fingerprint_meta(path)
+        if recorded is None:
+            return False
+        try:
+            return recorded["fingerprint"] == self.fingerprint()
+        except (KeyError, OSError):
+            return False
 
 
 class SourceArtifact(CompilationArtifact):
@@ -344,6 +593,15 @@ class FullElfArtifact(_MLIRInputMixin, CompilationArtifact):
         # Bytes of trace buffer per runlist step, 0 for an untraced build.
         self.trace_size = trace_size
 
+    def _fingerprint_payload(self) -> Any:
+        return {
+            "class": type(self).__name__,
+            "filename": self.filename,
+            "extra_flags": list(self.extra_flags),
+            "trace_size": self.trace_size,
+            "use_chess": getattr(self, "_use_chess", False),
+        }
+
 
 class XclbinArtifact(_MLIRInputMixin, CompilationArtifact):
     def __init__(
@@ -362,6 +620,18 @@ class XclbinArtifact(_MLIRInputMixin, CompilationArtifact):
         self.extra_flags = extra_flags if extra_flags is not None else []
         self.xclbin_input = xclbin_input
 
+    def _fingerprint_payload(self) -> Any:
+        payload = {
+            "class": type(self).__name__,
+            "filename": self.filename,
+            "kernel_name": self.kernel_name,
+            "extra_flags": list(self.extra_flags),
+            "use_chess": getattr(self, "_use_chess", False),
+        }
+        if self.xclbin_input is not None:
+            payload["xclbin_input"] = self.xclbin_input.filename
+        return payload
+
 
 class InstsBinArtifact(_MLIRInputMixin, CompilationArtifact):
     def __init__(
@@ -375,6 +645,14 @@ class InstsBinArtifact(_MLIRInputMixin, CompilationArtifact):
             dependencies = dependencies + [mlir_input]
         super().__init__(filename, dependencies)
         self.extra_flags = extra_flags if extra_flags is not None else []
+
+    def _fingerprint_payload(self) -> Any:
+        return {
+            "class": type(self).__name__,
+            "filename": self.filename,
+            "extra_flags": list(self.extra_flags),
+            "use_chess": getattr(self, "_use_chess", False),
+        }
 
 
 class KernelObjectArtifact(CompilationArtifact):
@@ -391,6 +669,16 @@ class KernelObjectArtifact(CompilationArtifact):
         self.rename_symbols = rename_symbols if rename_symbols is not None else {}
         self.prefix_symbols = prefix_symbols
 
+    def _fingerprint_payload(self) -> Any:
+        return {
+            "class": type(self).__name__,
+            "filename": self.filename,
+            "extra_flags": list(self.extra_flags),
+            "rename_symbols": dict(self.rename_symbols),
+            "prefix_symbols": self.prefix_symbols,
+            "use_chess": getattr(self, "_use_chess", False),
+        }
+
 
 class KernelArchiveArtifact(CompilationArtifact):
     """A static archive (.a) bundling one or more KernelObjectArtifacts."""
@@ -406,6 +694,22 @@ class PythonGeneratedMLIRArtifact(MLIRArtifact):
     ) -> None:
         self.generator = generator
         super().__init__(filename, dependencies=[SourceArtifact(generator.source_path)])
+
+    def _fingerprint_payload(self) -> Any:
+        """The Python design generator: its source file and its call arguments.
+
+        ``args``/``kwargs`` may hold non-JSON objects (a ``Device``, numpy
+        types), so they are serialised with ``default=str``; two generators
+        whose arguments convert the same are treated as equivalent, which is
+        the best we can do without deep-compare of live Python objects.
+        """
+        return {
+            "class": type(self).__name__,
+            "filename": self.filename,
+            "fn_name": self.generator.fn_name,
+            "args": list(self.generator.args),
+            "kwargs": dict(self.generator.kwargs),
+        }
 
 
 # Compilation Command
@@ -602,6 +906,7 @@ class AieccFullElfCompilationRule(AieccCompilationRule):
                     use_chess=self.use_chess,
                     verbose=True,
                 )
+                artifact.record_fingerprint()
 
             commands.append(PythonCallbackCompilationCommand(_compile))
             artifact.available = True
@@ -663,6 +968,7 @@ class AieccXclbinInstsCompilationRule(AieccCompilationRule):
                 insts_path=insts_path,
                 options=options,
                 work_dir=work_dir,
+                worklist=worklist,
             ):
                 work_dir.mkdir(parents=True, exist_ok=True)
                 _link_build_outputs_into(work_dir, Path(mlir_source.filename).parent)
@@ -675,6 +981,10 @@ class AieccXclbinInstsCompilationRule(AieccCompilationRule):
                     use_chess=self.use_chess,
                     verbose=True,
                 )
+                # Record fingerprints for every artifact this invocation produced.
+                for artifact in worklist:
+                    if artifact.mlir_input is mlir_source:
+                        artifact.record_fingerprint()
 
             commands.append(PythonCallbackCompilationCommand(_compile))
 
@@ -814,6 +1124,12 @@ class KernelCompilationRule(CompilationRule):
                 commands.extend(self._rename_symbols(artifact))
             if artifact.prefix_symbols:
                 commands.extend(self._prefix_symbols(artifact, artifact.prefix_symbols))
+
+            # Record the fingerprint only AFTER any symbol renaming/prefixing has
+            # rewritten the object, since those change its bytes.
+            commands.append(
+                PythonCallbackCompilationCommand(artifact.record_fingerprint)
+            )
             artifact.available = True
 
         return commands
@@ -880,6 +1196,10 @@ with open({repr(symbol_map_file)}, 'w') as f:
         ]
 
         return [ShellCompilationCommand(nm_cmd), ShellCompilationCommand(objcopy_cmd)]
+
+    def _record(self, artifact) -> None:
+        if hasattr(artifact, "record_fingerprint"):
+            artifact.record_fingerprint()
 
 
 class ArchiveCompilationRule(CompilationRule):

--- a/iron/common/compilation/sequence.py
+++ b/iron/common/compilation/sequence.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import numpy as np
 import importlib.util
 from functools import partial
-from pathlib import Path
 from aie import ir
 from aie.dialects import aie, aiex, memref
 from aie.extras.context import mlir_mod_ctx

--- a/iron/common/sequence.py
+++ b/iron/common/sequence.py
@@ -4,7 +4,6 @@
 import hashlib
 import logging
 import time
-from pathlib import Path
 import numpy as np
 import ml_dtypes
 from . import compilation as comp
@@ -514,12 +513,23 @@ class OperatorSequence(AIEOperatorBase):
 # Module helpers
 # ##########################################################################
 
+from iron.common.compilation.base import DataFlowTier
+
 
 BF16 = np.dtype(ml_dtypes.bfloat16)
+F32 = np.dtype(np.float32)
 
 
-def _n_elements(nbytes):
-    return max(nbytes, BF16.itemsize) // BF16.itemsize
+def _n_elements(nbytes, tier: DataFlowTier = DataFlowTier.BFLOAT16):
+    return max(nbytes, tier.itemsize) // tier.itemsize
+
+
+def _buffer_dtype_for_tier(tier: DataFlowTier):
+    """Return numpy dtype for given data flow tier."""
+    if tier == DataFlowTier.BFLOAT16:
+        return BF16
+    else:
+        return F32
 
 
 # ##########################################################################

--- a/iron/common/test_utils.py
+++ b/iron/common/test_utils.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import numpy as np
 import torch
 import aie.utils as aie_utils
-from ml_dtypes import bfloat16
 from .base import AIEOperatorBase
 
 torch_dtype_map = {

--- a/iron/operators/dequant/reference.py
+++ b/iron/operators/dequant/reference.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import numpy as np
-from ml_dtypes import bfloat16
 
 
 def generate_golden_reference(input_length, tile_size, group_size):

--- a/iron/operators/gemm/design.py
+++ b/iron/operators/gemm/design.py
@@ -4,7 +4,6 @@
 import argparse
 from pathlib import Path
 
-from ml_dtypes import bfloat16
 
 import numpy as np
 
@@ -173,28 +172,37 @@ def my_matmul(
     mem_tile_n = n * n_aie_cols
 
     if prio_accuracy:
-        assert (
-            dtype_out_str == "bf16"
-        ), f"prio_accuracy flag is a feature only for bfloat16 output data types"
+        if dtype_out_str != "bf16":
+            raise ValueError(
+                "prio_accuracy flag is a feature only for bfloat16 output data types "
+                f"(got {dtype_out_str!r})"
+            )
         use_larger_internal_buffer = True
         # If prio_accuracy flag is enabled, gemm for bfloat16 will accumulate in place with a f32 buffer,
         # which will be converted to bf16 after the reduction loop finishes for output transfer to L2
         dtype_out_internal = str_to_dtype("f32")
-        assert np.issubdtype(dtype_in, np.integer) == np.issubdtype(
+        if np.issubdtype(dtype_in, np.integer) != np.issubdtype(
             dtype_out_internal, np.integer
-        ), f"Input dtype ({dtype_in}) and output dtype ({dtype_out_internal}) must either both be integral or both be float"
-        assert (
-            np.dtype(dtype_out_internal).itemsize >= np.dtype(dtype_in).itemsize
-        ), f"Output dtype ({dtype_out_internal}) must be equal or larger to input dtype ({dtype_in})"
+        ):
+            raise ValueError(
+                f"Input dtype ({dtype_in}) and output dtype ({dtype_out_internal}) "
+                "must either both be integral or both be float"
+            )
+        if np.dtype(dtype_out_internal).itemsize < np.dtype(dtype_in).itemsize:
+            raise ValueError(
+                f"Output dtype ({dtype_out_internal}) must be equal or larger to input dtype ({dtype_in})"
+            )
     else:
         use_larger_internal_buffer = False
 
-    assert np.issubdtype(dtype_in, np.integer) == np.issubdtype(
-        dtype_out, np.integer
-    ), f"Input dtype ({dtype_in}) and output dtype ({dtype_out}) must either both be integral or both be float"
-    assert (
-        np.dtype(dtype_out).itemsize >= np.dtype(dtype_in).itemsize
-    ), f"Output dtype ({dtype_out}) must be equal or larger to input dtype ({dtype_in})"
+    if np.issubdtype(dtype_in, np.integer) != np.issubdtype(dtype_out, np.integer):
+        raise ValueError(
+            f"Input dtype ({dtype_in}) and output dtype ({dtype_out}) must either both be integral or both be float"
+        )
+    if np.dtype(dtype_out).itemsize < np.dtype(dtype_in).itemsize:
+        raise ValueError(
+            f"Output dtype ({dtype_out}) must be equal or larger to input dtype ({dtype_in})"
+        )
 
     # r, s, t are the dimensions required by the microkernel MAC instructions.
     mac_dims = microkernel_mac_dim_map[dev_name][dtype_in_str]
@@ -205,10 +213,10 @@ def my_matmul(
 
     # npu1 is a 4 row x 4 col array
     if dev_name == "npu1" and n_aie_cols > 4:
-        raise AssertionError("Invalid configuration: NPU (Phoenix/Hawk) has 4 columns")
+        raise ValueError("Invalid configuration: NPU (Phoenix/Hawk) has 4 columns")
     # npu2 is a 4 row x 8 col array
     if dev_name == "npu2" and n_aie_cols > 8:
-        raise AssertionError(
+        raise ValueError(
             "Invalid configuration: NPU2 (Strix/Strix Halo/Krackan) has 8 columns"
         )
 
@@ -217,34 +225,44 @@ def my_matmul(
     # blocks are _broadcast_ across AIE core columns, then _distributed_ across
     # rows, s.t. each of the n_rows compute cores in a column receives a
     # contiguous (m, k)-sized block of A.
-    assert (
-        M % mem_tile_m_A == 0
-    ), """A must be tileable into (m * n_A_tiles_per_shim, k)-sized blocks"""
+    if M % mem_tile_m_A != 0:
+        raise ValueError(
+            f"M ({M}) must be tileable into (m * n_A_tiles_per_shim, k)-sized "
+            f"blocks: M % ({mem_tile_m_A}) == {M % mem_tile_m_A}"
+        )
 
     # Both A and B are tiled in the K dimension into size k.
-    assert K % k == 0
+    if K % k != 0:
+        raise ValueError(f"K ({K}) must be a multiple of k ({k})")
 
     # Input matrix B:
     # Conceptually, we do the same as with A, but instead of broadcasting
     # across columns we broadcast across rows and distribute across columns.
-    assert (
-        N % mem_tile_n == 0
-    ), """B must be tileable into (k, n * n_aie_cols)-sized blocks"""
+    if N % mem_tile_n != 0:
+        raise ValueError(
+            f"N ({N}) must be tileable into (k, n * n_aie_cols)-sized blocks: "
+            f"N % ({mem_tile_n}) == {N % mem_tile_n}"
+        )
 
     # Output matrix C:
     # Conceptually, we divide output C into (m * n_rows, n)-sized blocks. These
     # blocks are _distributed_ across AIE core columns, and _joined_ across
     # rows, s.t. each of the n_rows compute cores in a column send a
     # contiguous (m, n)-sized block of C.
-    assert (
-        M % mem_tile_m_C == 0
-    ), """C must be tileable into (m * n_aie_rows, n)-sized blocks"""
+    if M % mem_tile_m_C != 0:
+        raise ValueError(
+            f"M ({M}) must be tileable into (m * n_aie_rows, n)-sized blocks: "
+            f"M % ({mem_tile_m_C}) == {M % mem_tile_m_C}"
+        )
 
     # r, s, t are the dimensions required by the microkernel MAC instructions.
     if not use_scalar:
-        assert m % r == 0
-        assert k % s == 0
-        assert n % t == 0
+        if m % r != 0:
+            raise ValueError(f"tile_m ({m}) must be a multiple of r ({r})")
+        if k % s != 0:
+            raise ValueError(f"tile_k ({k}) must be a multiple of s ({s})")
+        if n % t != 0:
+            raise ValueError(f"tile_n ({n}) must be a multiple of t ({t})")
 
     # If you get errors during CDO generation due to running out of program
     # memory, it may be because too much code is generated due to ObjectFIFO

--- a/iron/operators/gemv/design.py
+++ b/iron/operators/gemv/design.py
@@ -48,13 +48,22 @@ def my_matvec(
         print(f"Columns: {cols}")
 
     # The reason for the following requirement is because we first acquire output rows from the C FIFO, then fill those acquiring rows of the A input.
-    assert (
-        m_output % m_input == 0 and m_output >= m_input
-    ), "m_output must be a multiple of m_input"
-    assert m_output <= M // cols, "m_output must be less than or equal to M/cols"
-    assert (M // cols) % m_output == 0, "m_output must evenly divide M/cols"
-    assert m_input <= M // cols, "m_input must be less than or equal to M/cols"
-    assert (M // cols) % m_input == 0, "m_input must evenly divide M/cols"
+    if not (m_output % m_input == 0 and m_output >= m_input):
+        raise ValueError(
+            f"m_output ({m_output}) must be a multiple of m_input ({m_input})"
+        )
+    if m_output > M // cols:
+        raise ValueError(
+            f"m_output ({m_output}) must be less than or equal to M/cols ({(M // cols)})"
+        )
+    if (M // cols) % m_output != 0:
+        raise ValueError(f"(M // cols) ({M // cols}) must evenly divide m_output ({m_output})")
+    if m_input > M // cols:
+        raise ValueError(
+            f"m_input ({m_input}) must be less than or equal to M/cols ({(M // cols)})"
+        )
+    if (M // cols) % m_input != 0:
+        raise ValueError(f"(M // cols) ({M // cols}) must evenly divide m_input ({m_input})")
 
     vectorized = True
     dtype_in = np.dtype[bfloat16]
@@ -62,7 +71,8 @@ def my_matvec(
     dtype_out = np.dtype[bfloat16]
     dtype_out_str = "bf16"
 
-    assert M % cols == 0
+    if M % cols != 0:
+        raise ValueError(f"M ({M}) must be a multiple of cols ({cols})")
 
     L1_A_ty = np.ndarray[
         (
@@ -89,12 +99,16 @@ def my_matvec(
     # Optional fused activation over the full m_output C-tile, applied once per tile in core_body
     # (after the matvec inner-loop has filled all rows) rather than per matvec call, whose m_input
     # tile can be smaller than the 16-wide activation vector.
-    assert epilogue in ("none", "gelu")
+    if epilogue not in ("none", "gelu"):
+        raise ValueError(
+            f"unknown epilogue {epilogue!r} (expected 'none' or 'gelu')"
+        )
     gelu_kernel = None
     if epilogue == "gelu":
-        assert (
-            m_output % 16 == 0
-        ), f"gelu epilogue needs m_output % 16 == 0 (got {m_output})"
+        if m_output % 16 != 0:
+            raise ValueError(
+                f"gelu epilogue needs m_output % 16 == 0 (got {m_output})"
+            )
         gelu_kernel = Kernel(
             f"{func_prefix}gelu_tile_bf16",
             f"{func_prefix}{kernel_object}",
@@ -238,9 +252,12 @@ def my_matvec(
         # overrun). depth>=2 only buys OVERLAP of fill with compute, so it is a
         # performance guard here, not a correctness requirement (depth==1 is correct but
         # fully serial).
-        assert all(f.depth >= 2 for f in A_L3L1_fifos) and all(
+        if not (all(f.depth >= 2 for f in A_L3L1_fifos) and all(
             f.depth >= 2 for f in C_L1L3_fifos
-        ), "coalesced GEMV wants A/C ObjectFifo depth>=2 for fill/compute overlap"
+        )):
+            raise ValueError(
+                "coalesced GEMV wants A/C ObjectFifo depth>=2 for fill/compute overlap"
+            )
         A_taps_coalesced = [
             coalesced_tap(L3_A_ty, col * (M // cols) * K, A_split, A_bstride)
             for col in range(cols)

--- a/iron/operators/gemv/reference.py
+++ b/iron/operators/gemv/reference.py
@@ -3,7 +3,6 @@
 
 import torch
 import numpy as np
-from ml_dtypes import bfloat16
 
 
 def reference(A, B):

--- a/iron/operators/leaky_relu/op.py
+++ b/iron/operators/leaky_relu/op.py
@@ -4,7 +4,6 @@
 from dataclasses import dataclass
 from typing import ClassVar, Dict
 
-import aie.utils as aie_utils
 from iron.common import (
     ChanneledUnaryOperator,
     PythonGeneratedMLIRArtifact,

--- a/iron/operators/mem_copy/design.py
+++ b/iron/operators/mem_copy/design.py
@@ -16,7 +16,7 @@ from aie.iron import (
     Runtime,
     Worker,
 )
-from aie.iron.device import Tile, NPU1, NPU2
+from aie.iron.device import Tile
 from aie.helpers.taplib.tap import TensorAccessPattern
 from aie.iron.controlflow import range_
 from aie.iron.runtime.endpoint import RuntimeEndpoint

--- a/iron/operators/mha/design.py
+++ b/iron/operators/mha/design.py
@@ -148,9 +148,8 @@ def fused_mha(
     if num_KV_heads == 0:
         num_KV_heads = heads
 
-    assert (
-        emulate_bf16_mmul_with_bfp16
-    ), "Only emulate_bf16_mmul_with_bfp16=True is supported"
+    if not emulate_bf16_mmul_with_bfp16:
+        raise ValueError("Only emulate_bf16_mmul_with_bfp16=True is supported")
 
     # r, s, t are the dimensions required by the microkernel MAC instructions.
     mac_dims = microkernel_mac_dim_map["npu2"][dtype_str]
@@ -166,21 +165,31 @@ def fused_mha(
         print(f"Vectorized: {vectorized}")
         print(f"Enable tracing: {enable_tracing}")
 
-    assert num_KV_heads > 0, "Number of KV heads must be greater than 0"
-    assert heads > 0, "Number of heads must be greater than 0"
-    assert (
-        num_KV_heads <= heads
-    ), "Number of KV heads must be less than or equal to number of heads"
-    assert (
-        heads % num_KV_heads == 0
-    ), f"Number of heads ({heads}) must be divisible by number of KV heads ({num_KV_heads})"
+    if num_KV_heads <= 0:
+        raise ValueError("Number of KV heads must be greater than 0")
+    if heads <= 0:
+        raise ValueError("Number of heads must be greater than 0")
+    if num_KV_heads > heads:
+        raise ValueError(
+            "Number of KV heads must be less than or equal to number of heads"
+        )
+    if heads % num_KV_heads != 0:
+        raise ValueError(
+            f"Number of heads ({heads}) must be divisible by number of KV heads "
+            f"({num_KV_heads})"
+        )
 
-    assert B_q % r == 0, f"B_q must be divisible by r ({B_q} % {r} != 0)"
-    assert B_kv % t == 0, f"B_kv must be divisible by t ({B_kv} % {t} != 0)"
-    assert d % s == 0, f"d must be divisible by s ({d} % {s} != 0)"
+    if B_q % r != 0:
+        raise ValueError(f"B_q ({B_q}) must be divisible by r ({r})")
+    if B_kv % t != 0:
+        raise ValueError(f"B_kv ({B_kv}) must be divisible by t ({t})")
+    if d % s != 0:
+        raise ValueError(f"d ({d}) must be divisible by s ({s})")
 
-    assert S_q_pad % B_q == 0, "Padded S_q must be divisible by B_q"
-    assert S_kv_pad % B_kv == 0, "Padded S_kv must be divisible by B_kv"
+    if S_q_pad % B_q != 0:
+        raise ValueError("Padded S_q must be divisible by B_q")
+    if S_kv_pad % B_kv != 0:
+        raise ValueError("Padded S_kv must be divisible by B_kv")
 
     dtype = dtype_map[dtype_str]
 
@@ -216,7 +225,7 @@ def fused_mha(
     zero_kernel = Kernel(f"zero_{dtype_str}", "mha.o", [qk_ty])
 
     memcopy_kernel_scale = Kernel(
-        f"passThroughLine", "mha_passThrough.o", [s_ty, s_ty, np.int32]
+        "passThroughLine", "mha_passThrough.o", [s_ty, s_ty, np.int32]
     )
 
     scale_buffer_init_kernel = Kernel("init_scale_buffer", "mha.o", [s_ty, np.int32])
@@ -750,8 +759,9 @@ def fused_mha(
         # Check that the transfer is continuous
         for idx, stride in enumerate(tap._strides[:-1]):
             if stride != 0 and stride != tap._sizes[idx + 1]:
-                raise ValueError(f"Cannot legalize DMA non-contiguous DMA transfer")
-        assert tap._strides[-1] == 1, f"Cannot legalize DMA non-contiguous DMA transfer"
+                raise ValueError("Cannot legalize DMA non-contiguous DMA transfer")
+        if tap._strides[-1] != 1:
+            raise ValueError("Cannot legalize DMA non-contiguous DMA transfer")
 
         tap._sizes = [1, 1, 1, math.prod(sizes)]
         tap._strides = [0, 0, 0, 1]
@@ -769,7 +779,7 @@ def fused_mha(
     legalize_tas(V_tiles)
 
     if verbose:
-        print(f"DMA Transfer Configuration: DRAM <-> Mem tile")
+        print("DMA Transfer Configuration: DRAM <-> Mem tile")
         # print_tap_seq_info(Q_tiles, "Q")
         print_tap_seq_info(K_tiles, "K")
         print_tap_seq_info(V_tiles, "V")

--- a/iron/operators/mha/reference.py
+++ b/iron/operators/mha/reference.py
@@ -5,7 +5,6 @@ import torch
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 import numpy as np
-from ml_dtypes import bfloat16
 
 
 def pad_to_multiple_of_64(tensor, seq_dim, num_pipeline=1):

--- a/iron/operators/rms_norm/design.py
+++ b/iron/operators/rms_norm/design.py
@@ -5,7 +5,6 @@ from ml_dtypes import bfloat16
 import numpy as np
 
 from aie.iron import Kernel, ObjectFifo, Program, Runtime, TaskGroup, Worker
-from aie.iron.device import NPU1, NPU2
 from aie.helpers.taplib.tap import TensorAccessPattern
 from aie.iron.controlflow import range_
 

--- a/iron/operators/rms_norm/design_weighted.py
+++ b/iron/operators/rms_norm/design_weighted.py
@@ -5,7 +5,6 @@ from ml_dtypes import bfloat16
 import numpy as np
 
 from aie.iron import Kernel, ObjectFifo, Program, Runtime, TaskGroup, Worker
-from aie.iron.device import NPU1, NPU2
 from aie.helpers.taplib.tap import TensorAccessPattern
 from aie.iron.controlflow import range_
 

--- a/iron/operators/rope/design.py
+++ b/iron/operators/rope/design.py
@@ -18,7 +18,6 @@ Another interpretation of the input tensor is (rows / num_heads, num_heads, cols
 import numpy as np
 
 from aie.iron import Kernel, ObjectFifo, Program, Runtime, TaskGroup, Worker
-from aie.iron.device import NPU1, NPU2
 from aie.helpers.taplib.tap import TensorAccessPattern
 from aie.helpers.dialects.scf import _for as range_
 from ml_dtypes import bfloat16
@@ -45,14 +44,20 @@ def rope(
         + ".o"
     )
 
-    assert cols % (16 * 2) == 0 and cols >= (
-        16 * 2
-    ), "cols must be multiple of 32 and >= 32 (rope.cc kernel processes two 16-element vectors at a time)"
-    assert rows % num_aie_columns == 0, "rows must be divisible by num_aie_columns"
-    assert angle_rows <= rows and rows % angle_rows == 0, "angle_rows must divide rows"
-    assert (
-        angle_rows >= num_aie_columns and angle_rows % num_aie_columns == 0
-    ), "angle_rows must be divisible by num_aie_columns"
+    if cols % (16 * 2) != 0 or cols < (16 * 2):
+        raise ValueError(
+            f"cols ({cols}) must be a multiple of 32 and >= 32 (rope.cc kernel "
+            "processes two 16-element vectors at a time)"
+        )
+    if rows % num_aie_columns != 0:
+        raise ValueError(f"rows ({rows}) must be divisible by num_aie_columns ({num_aie_columns})")
+    if angle_rows > rows or rows % angle_rows != 0:
+        raise ValueError(f"angle_rows ({angle_rows}) must divide rows ({rows})")
+    if angle_rows < num_aie_columns or angle_rows % num_aie_columns != 0:
+        raise ValueError(
+            f"angle_rows ({angle_rows}) must be divisible by num_aie_columns "
+            f"({num_aie_columns})"
+        )
 
     tensor_rows_per_aie_column = rows // num_aie_columns
     angle_rows_per_aie_column = angle_rows // num_aie_columns

--- a/iron/operators/rope/reference.py
+++ b/iron/operators/rope/reference.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import numpy as np
-from ml_dtypes import bfloat16
 
 
 def compute_rope_params(

--- a/iron/operators/softmax/design.py
+++ b/iron/operators/softmax/design.py
@@ -16,7 +16,6 @@ from aie.iron import (
     WorkerRuntimeBarrier,
     sync_parameters,
 )
-from aie.iron.device import NPU1, NPU2
 from aie.helpers.taplib.tap import TensorAccessPattern
 from aie.helpers.dialects.scf import _for as range_
 from ml_dtypes import bfloat16

--- a/iron/operators/strided_copy/design.py
+++ b/iron/operators/strided_copy/design.py
@@ -37,8 +37,16 @@ def strided_copy(
     input_offset_parameter=None,
     output_offset_parameter=None,
 ):
-    assert len(input_sizes) == len(input_strides)
-    assert len(output_sizes) == len(output_strides)
+    if len(input_sizes) != len(input_strides):
+        raise ValueError(
+            f"input_sizes and input_strides must have the same length "
+            f"({len(input_sizes)} vs {len(input_strides)})"
+        )
+    if len(output_sizes) != len(output_strides):
+        raise ValueError(
+            f"output_sizes and output_strides must have the same length "
+            f"({len(output_sizes)} vs {len(output_strides)})"
+        )
 
     # Pad out dimensions to 4D; dropping leading dimensions leads to compiler not initializing these registers, causing hard-to-debug errors
     input_sizes = [1] * (4 - len(input_sizes)) + list(input_sizes)
@@ -48,30 +56,34 @@ def strided_copy(
 
     input_highest_sz_idx = max(idx for idx, sz in enumerate(input_sizes) if sz >= 1)
     output_highest_sz_idx = max(idx for idx, sz in enumerate(output_sizes) if sz >= 1)
-    assert (
-        input_sizes[input_highest_sz_idx] % num_aie_channels == 0
-    ), "Highest dimension of input_sizes must be divisible by num_aie_channels"
-    assert (
-        output_sizes[output_highest_sz_idx] % num_aie_channels == 0
-    ), "Highest dimension of output_sizes must be divisible by num_aie_channels"
+    if input_sizes[input_highest_sz_idx] % num_aie_channels != 0:
+        raise ValueError(
+            "Highest dimension of input_sizes must be divisible by num_aie_channels"
+        )
+    if output_sizes[output_highest_sz_idx] % num_aie_channels != 0:
+        raise ValueError(
+            "Highest dimension of output_sizes must be divisible by num_aie_channels"
+        )
 
     # Each channel's BD carries 1/num_aie_channels of the tensor, so the ObjectFifo object
     # is sized against the per-channel share. A BD shorter than the object starves the
     # MemTile's S2MM -- it never completes an object, never releases the lock, and the
     # drain's dma_await_task never returns (ERT_CMD_STATE_TIMEOUT). An integer multiple is
     # fine; it just cycles the buffer.
-    assert int(np.prod(input_sizes)) == int(np.prod(output_sizes)), (
-        f"a copy moves the same element count both ways: input_sizes {input_sizes} "
-        f"has {int(np.prod(input_sizes))} elements, output_sizes {output_sizes} has "
-        f"{int(np.prod(output_sizes))}"
-    )
+    if int(np.prod(input_sizes)) != int(np.prod(output_sizes)):
+        raise ValueError(
+            f"a copy moves the same element count both ways: input_sizes {input_sizes} "
+            f"has {int(np.prod(input_sizes))} elements, output_sizes {output_sizes} has "
+            f"{int(np.prod(output_sizes))}"
+        )
     per_channel_size = int(np.prod(input_sizes)) // num_aie_channels
     if transfer_size is None:
         transfer_size = per_channel_size
-    assert per_channel_size % transfer_size == 0, (
-        f"transfer_size {transfer_size} must divide the per-channel transfer "
-        f"{per_channel_size} (= {int(np.prod(input_sizes))} / {num_aie_channels} channels)"
-    )
+    if per_channel_size % transfer_size != 0:
+        raise ValueError(
+            f"transfer_size {transfer_size} must divide the per-channel transfer "
+            f"{per_channel_size} (= {int(np.prod(input_sizes))} / {num_aie_channels} channels)"
+        )
     transfer_ty = np.ndarray[
         (transfer_size,),
         np.dtype[dtype],

--- a/iron/operators/swiglu_decode/reference.py
+++ b/iron/operators/swiglu_decode/reference.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import numpy as np
-from ml_dtypes import bfloat16
 
 
 def generate_golden_reference(M=1, K=2048, N=8192, seed=42):


### PR DESCRIPTION
Introduce deterministic build-product fingerprinting and tooling-aware cache invalidation in iron/common/compilation/base.py: DataFlowTier enum, toolchain fingerprint, .meta sidecars, fingerprint() logic, and record_fingerprint() calls to record/revalidate artifacts. Switch availability checks to compare fingerprints instead of mtimes. Record fingerprints after kernel/xclbin/ELF production. Replace many in-code assert checks across operators with user-friendly ValueError messages and clearer diagnostics (gemm, gemv, gemv/ref, gemv/design, mha, rope, strided_copy, strided_copy/design, mem_copy, softmax, rms_norm, etc.). Misc cleanup: remove unused imports, tidy prints, adjust kernel name usage, and small import reorders (pretty_aggregate, conftest, llama harness). These changes improve build caching correctness and make runtime parameter validation more explicit and debuggable.

<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

Describe the intent of your PR here.

## Added
-

## Changed
-

## Removed
-

## PR Merge Checklist

1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
