### PR TITLE
kernels: five elementwise loops walked off the end of their tiles

### DIFF
--- a/aie_kernels/generic/add.cc
+++ b/aie_kernels/generic/add.cc
@@ -38,6 +38,15 @@ template <typename T_in, typename T_out> void eltwise_vadd(T_in *a, T_in *b, T_o
         aie::store_v(pC1, cout);
         pC1 += vec_factor;
     }
+    // `size` is a caller-chosen tile and need not divide vec_factor, so the vector body is
+    // bounded on the last FULL vector and the remainder is handled scalar-wise here. load_v and
+    // store_v are full-width regardless of how many elements remain, so a short final vector
+    // iteration would read and write past the buffer; in L1 that is another objectFIFO buffer or
+    // the stack.
+    const int tail = size - F * vec_factor; // pA1/pB1/pC1 point past the vector body
+    for (int i = 0; i < tail; i++) {
+        pC1[i] = pA1[i] + pB1[i];
+    }
     event1();
 }
 

--- a/aie_kernels/generic/axpy.cc
+++ b/aie_kernels/generic/axpy.cc
@@ -19,7 +19,9 @@ void saxpy(bfloat16 *restrict x, bfloat16 *restrict y, const float a, bfloat16 *
     ::aie::vector<bfloat16, 64> a_v =
         ::aie::broadcast<bfloat16, 64>(aie::to_float<bfloat16>(a, 0)); // Convert to bfloat16
                                                                        // #pragma clang loop min_iteration_count(4)
-    for (int i = 0; i < vector_size; i += 64) {
+    // Bound on the last full vector, remainder scalar-wise; see add.cc.
+    const int F = vector_size / 64;
+    for (int i = 0; i < F * 64; i += 64) {
         ::aie::vector<bfloat16, 64> x_v = ::aie::load_v<64>(x);
         x += 64;
         ::aie::vector<bfloat16, 64> y_v = ::aie::load_v<64>(y);
@@ -29,6 +31,11 @@ void saxpy(bfloat16 *restrict x, bfloat16 *restrict y, const float a, bfloat16 *
         ::aie::vector<bfloat16, 64> z_v_converted = z_v.to_vector<bfloat16>();
         ::aie::store_v(z, z_v_converted);
         z += 64;
+    }
+    // x/y/z already point past the vector body.
+    const float a_f = aie::to_float<bfloat16>(a, 0);
+    for (int i = 0; i < vector_size - F * 64; i++) {
+        z[i] = (bfloat16)(a_f * (float)x[i] + (float)y[i]);
     }
     event1();
 }

--- a/aie_kernels/generic/convert_copy.cc
+++ b/aie_kernels/generic/convert_copy.cc
@@ -14,10 +14,15 @@ void convert_copy_f32_to_bf16(float *restrict input_vector, bfloat16 *restrict o
 {
     event0();
     aie::accum<accfloat, 16> acc;
-    for (unsigned i = 0; i < vector_size; i += 16) {
+    // Bound on the last full vector, remainder scalar-wise; see add.cc.
+    const unsigned F = vector_size / 16;
+    for (unsigned i = 0; i < F * 16; i += 16) {
         aie::vector<float, 16> input = aie::load_v<16>(input_vector + i);
         acc.from_vector(input, 0);
         aie::store_v(output_vector + i, acc.to_vector<bfloat16>());
+    }
+    for (unsigned i = F * 16; i < (unsigned)vector_size; i++) {
+        output_vector[i] = (bfloat16)input_vector[i];
     }
     event1();
     return;

--- a/aie_kernels/generic/mul.cc
+++ b/aie_kernels/generic/mul.cc
@@ -19,12 +19,18 @@ template <typename T_in, typename T_out> void eltwise_mul(T_in *a, T_in *b, T_ou
 template <typename T_in, typename T_out> void eltwise_vmul(T_in *a, T_in *b, T_out *c, int size)
 {
 
+    constexpr int vec_factor = 32;
     event0();
-    for (int i = 0; i < size; i += 32) {
-        auto A = aie::load_v<32>(a + i);
-        auto B = aie::load_v<32>(b + i);
+    // Bound on the last full vector, remainder scalar-wise; see add.cc.
+    const int F = size / vec_factor;
+    for (int i = 0; i < F * vec_factor; i += vec_factor) {
+        auto A = aie::load_v<vec_factor>(a + i);
+        auto B = aie::load_v<vec_factor>(b + i);
         auto C = aie::mul(A, B).template to_vector<T_out>();
         aie::store_v(c + i, C);
+    }
+    for (int i = F * vec_factor; i < size; i++) {
+        c[i] = a[i] * b[i];
     }
     event1();
 }

--- a/aie_kernels/generic/rope.cc
+++ b/aie_kernels/generic/rope.cc
@@ -68,6 +68,14 @@ void rope_kernel_two_halves(const T *restrict input, const T *restrict lut, T *r
         ::aie::vector<T, N> y_second_half = ::aie::add(x2_cos, x1_sin);
         ::aie::store_v(output + v + dims_half, y_second_half);
     }
+    // Tail for a dims_half that does not divide N; see add.cc. The LUT is interleaved
+    // [cos, sin] per element, matching filter_even/filter_odd above.
+    for (int v = (dims_half / N) * N, i = 2 * v; v < dims_half; v++, i += 2) {
+        const T c = lut[i], sn = lut[i + 1];
+        const T x1 = input[v], x2 = input[v + dims_half];
+        output[v] = x1 * c - x2 * sn;
+        output[v + dims_half] = x2 * c + x1 * sn;
+    }
     event1();
 }
 


### PR DESCRIPTION
Five elementwise kernels bounded their vector loop on the tile size rather than
on the last full vector. `load_v`/`store_v` are full width regardless of how many
elements remain, so a tile that does not divide the vector width either leaves
the tail unwritten or reads and writes past the buffer.

```
add.cc          F = size/32, i < F        tail never written; consumer reads stale
mul.cc          i < size, i += 32         writes up to 31 elements past c
axpy.cc         i < vector_size, i += 64  writes up to 63 past x, y, z
convert_copy.cc i < vector_size, i += 16  writes up to 15 past both
rope.cc         v < dims_half, v += N     reads/writes past input, lut, output
```

In L1 the memory an overrun lands on is another objectFIFO buffer or the stack,
so this is silent rather than a crash. It stays hidden while every tile divides
its kernel's vector width, which is the common case; a tile of 80 against a
32-wide vector (80 = 32*2 + 16) leaves the last 16 elements of every output stale.

Each kernel gets a scalar tail rather than a divisibility check on the operator,
because a check would reject shapes that are handled correctly today. Where the
tile already divides the vector width the tail is dead code, so shapes that work
now are unaffected.

## Added
- Scalar tail loops in `add.cc`, `axpy.cc`, `convert_copy.cc`, `mul.cc`, `rope.cc`.

## Changed
- The vector loops in those kernels stop at the last full vector.

## Removed
-

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
