### PR TITLE
gemv: the shim stride bound was in elements, the field counts granules

### DIFF
--- a/iron/operators/gemv/design.py
+++ b/iron/operators/gemv/design.py
@@ -196,8 +196,10 @@ def my_matvec(
     # hard-coding them; they live in verifyStridesWraps in
     # https://github.com/Xilinx/mlir-aie/blob/main/lib/Dialect/AIEX/IR/AIEXDialect.cpp
     MAX_WRAP = 1023
-    MAX_STRIDE = (1 << 20) - 1  # conservative element-stride bound for the wrap dims
     GRAN_ELEMS = 2  # 4-byte shim granularity / 2-byte bf16 element
+    # The 20-bit shim BD step field counts address granules, not elements, so the
+    # bound converts: an element-unit bound is 2x too strict for bf16.
+    MAX_STRIDE = ((1 << 20) - 1) * GRAN_ELEMS
 
     def split_run(run, lim=MAX_WRAP, gran=GRAN_ELEMS):
         """Factor a contiguous run into (hi, lo), both <= lim and lo a multiple of gran


### PR DESCRIPTION
`MAX_STRIDE = (1 << 20) - 1` is the shim NOC tile's BD step field width, which
`AIETargetModel::getDmaBdStepBits` gives as 20 bits for `ShimNOCTile` (17 for a
mem tile, 13 for a core tile). That field counts **address granules, not
elements**: `getAddressGenGranularity()` returns 32 on AIE2/AIE2P, and
`encodeHardwareStridesWraps` scales an element stride by
`elemWidth / addressGranularity` before `verifyStridesWraps` looks at it.

The bound was written in elements and compared against the granule field width,
so for bf16 it is exactly 2x too strict and rejects batched shapes the hardware
accepts. The `FIXME` directly above it predicted this ("pull these shim BD bounds
from the MLIR-AIE target model rather than hard-coding them"); the comment called
the number conservative when it was simply in the wrong unit.

Scope: `MAX_STRIDE` is only read by the `coalesce` predicate. A shape it rejects
falls back to the per-batch path, so this widens what coalesces and does not
change any result.

## Added
-

## Changed
- `MAX_STRIDE` converts the 20-bit granule field width into elements via `GRAN_ELEMS`.

## Removed
-

## PR Merge Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
