### PR TITLE
mem_copy: pass -DBIT_WIDTH=16 when compiling passThrough.cc

### DIFF
--- a/iron/operators/mem_copy/op.py
+++ b/iron/operators/mem_copy/op.py
@@ -60,6 +60,7 @@ class MemCopy(MLIROperator):
         return [
             KernelObjectArtifact(
                 "mem_copy.o",
+                extra_flags=["-DBIT_WIDTH=16"],
                 dependencies=[
                     SourceArtifact(
                         self.context.base_dir


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

passThrough.cc selects the wrapper element width with BIT_WIDTH. MHA already passes -DBIT_WIDTH=16 for the same kernel; mem_copy uses bfloat16 and must too. Unset BIT_WIDTH now defaults to 32.

## Added
-

## Changed
-

## Removed
-

## PR Merge Checklist

1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [ ] Your PR has been reviewed and approved.
3. [ ] All checks are passing.
